### PR TITLE
Add example Wasm data transforms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Compiled wasm artifacts
+*.wasm

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Contributions are welcome. Just fork the repo (or submodule) and send a pull req
 | Project       | Description   |
 | ------------- | ------------- |
 | [`redpanda-edge-agent`](https://github.com/redpanda-data/redpanda-edge-agent) | Lightweight Internet of Things (IoT) agent that forwards events from the edge. |
+| [`data-transforms`](https://github.com/redpanda-data/redpanda-labs/data-transforms) | Example topic data transforms powered by WebAssembly (Wasm). |
 
 ## Update submodules
 

--- a/data-transforms/README.md
+++ b/data-transforms/README.md
@@ -1,0 +1,8 @@
+# Redpanda Data Transforms
+
+Redpanda Data transforms allow you to transform a topic's records into another topic without ping-ponging 
+your data into another distributed system.
+
+This directory contains a set of prebuilt transformations that you can build and deploy to your cluster.
+
+Transform can be configured using environment variables, see the individual READMEs for more information.

--- a/data-transforms/regex/README.md
+++ b/data-transforms/regex/README.md
@@ -1,0 +1,16 @@
+# Redpanda Wasm Data Transform - Regex Filter
+
+This contains an example of using a regular expression to filter a topic into another.
+
+Regular expression are implemented using Go's regexp library, which uses the same syntax as RE2.
+See the RE2 wiki for allowed syntax: https://github.com/google/re2/wiki/Syntax
+
+Environment variables:
+- `PATTERN`: The regular expression that will match against records (required)
+- `MATCH_VALUE`: By default, the regex matches keys, but if set to true, the regex will match values
+
+To deploy this to a cluster you'll need to run the following in this directory:
+```
+rpk transform build
+rpk transform deploy --env-var=PATTERN=myregex --input-topic=src --output-topic=sink
+```

--- a/data-transforms/regex/go.mod
+++ b/data-transforms/regex/go.mod
@@ -1,0 +1,5 @@
+module regex
+
+go 1.20
+
+require github.com/rockwotj/redpanda/src/go/sdk v0.0.0-20230624114529-2627fe2648dd

--- a/data-transforms/regex/go.sum
+++ b/data-transforms/regex/go.sum
@@ -1,0 +1,2 @@
+github.com/rockwotj/redpanda/src/go/sdk v0.0.0-20230624114529-2627fe2648dd h1:45ofwvK8qRWB2qc8XxLcYQFFMFGs4JTwBiEpX2I7irs=
+github.com/rockwotj/redpanda/src/go/sdk v0.0.0-20230624114529-2627fe2648dd/go.mod h1:23S80kD79G/N+gmtq/fGD7NqOFoh3zJhVmFW9I7pwUo=

--- a/data-transforms/regex/transform.go
+++ b/data-transforms/regex/transform.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"os"
+	"regexp"
+	"strings"
+
+	"github.com/rockwotj/redpanda/src/go/sdk"
+)
+
+var (
+	// Prevent alloc on the transform path
+	resultSlice []redpanda.Record = make([]redpanda.Record, 1)
+	re          *regexp.Regexp    = nil
+	checkValue  bool              = false
+)
+
+func isTrueVar(v string) bool {
+	switch strings.ToLower(v) {
+	case "yes", "ok", "1", "true":
+		return true
+	default:
+		return false
+	}
+}
+
+func main() {
+	// setup the configuration
+	pattern, ok := os.LookupEnv("PATTERN")
+	if !ok {
+		panic("Missing PATTERN variable")
+	}
+	re = regexp.MustCompile(pattern)
+	mk, ok := os.LookupEnv("MATCH_VALUE")
+	checkValue = ok && isTrueVar(mk)
+
+	redpanda.OnRecordWritten(doRegexFilter)
+}
+
+func doRegexFilter(e redpanda.WriteEvent) ([]redpanda.Record, error) {
+	var b []byte
+	if checkValue {
+		b = e.Record().Value
+	} else {
+		b = e.Record().Key
+	}
+	if b == nil {
+		return nil, nil
+	}
+	pass := re.Match(b)
+	if pass {
+		resultSlice[0] = e.Record()
+		return resultSlice, nil
+	} else {
+		return nil, nil
+	}
+}

--- a/data-transforms/regex/transform.yaml
+++ b/data-transforms/regex/transform.yaml
@@ -1,0 +1,15 @@
+name: regex
+description: |
+  Filters the input topic to records that only match a regular expression.
+
+  Regular expression are implemented using Go's regexp library, which uses the same syntax as RE2.
+  See the RE2 wiki for allowed syntax: https://github.com/google/re2/wiki/Syntax
+
+  Environment variables:
+  - PATTERN: The regular expression that will match against records (required)
+  - MATCH_VALUE: By default, the regex matches keys, but if set to true, the regex will match values
+input-topic: ""
+output-topic: ""
+language: tinygo
+env:
+  PATTERN: '<required>'


### PR DESCRIPTION
Starting with a simple regex filter, we can continue to provide examples
here and have a registry of prebuilt transforms for users to plug into
their system.
