### PR TITLE
Update data transform SDK

### DIFF
--- a/data-transforms/regex/go.mod
+++ b/data-transforms/regex/go.mod
@@ -2,4 +2,4 @@ module regex
 
 go 1.20
 
-require github.com/rockwotj/redpanda/src/go/sdk v0.0.0-20230624114529-2627fe2648dd
+require github.com/redpanda-data/redpanda/src/go/transform-sdk v0.0.0-20230817144152-d6608c5058fb

--- a/data-transforms/regex/go.sum
+++ b/data-transforms/regex/go.sum
@@ -1,2 +1,2 @@
-github.com/rockwotj/redpanda/src/go/sdk v0.0.0-20230624114529-2627fe2648dd h1:45ofwvK8qRWB2qc8XxLcYQFFMFGs4JTwBiEpX2I7irs=
-github.com/rockwotj/redpanda/src/go/sdk v0.0.0-20230624114529-2627fe2648dd/go.mod h1:23S80kD79G/N+gmtq/fGD7NqOFoh3zJhVmFW9I7pwUo=
+github.com/redpanda-data/redpanda/src/go/transform-sdk v0.0.0-20230817144152-d6608c5058fb h1:hDglNXmsj2NvcLr2kdnL/ER/lGOZYPxoHHO6B1e1+Qk=
+github.com/redpanda-data/redpanda/src/go/transform-sdk v0.0.0-20230817144152-d6608c5058fb/go.mod h1:BQiPywle7oxZRv+W++XektR1izbtSAMJ0PNSPtLfJvE=

--- a/data-transforms/regex/transform.go
+++ b/data-transforms/regex/transform.go
@@ -5,7 +5,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/rockwotj/redpanda/src/go/sdk"
+	redpanda "github.com/redpanda-data/redpanda/src/go/transform-sdk"
 )
 
 var (


### PR DESCRIPTION
This uses the offical SDK we've launched today in our tech preview,
instead of the private one in my GitHub repo.
