### PR TITLE
Add a "flatten" transform example for JSON data.

### DIFF
--- a/data-transforms/flatten/README.md
+++ b/data-transforms/flatten/README.md
@@ -1,0 +1,60 @@
+# Redpanda Wasm Data Transform - Flatten
+
+This project provides a JSON flattener, taking input JSON such as:
+
+```json
+{
+  "content": {
+    "id": 123,
+    "name": {
+      "first": "Dave",
+      "middle": null,
+      "last": "Voutila"
+    },
+    "data": [1, "fish", 2, "fish"]
+  }
+}
+```
+
+Turning it into:
+
+```json
+{
+  "content.id": 123,
+  "content.name.first": "Dave",
+  "content.name.middle": null,
+  "content.name.last": "Voutila",
+  "content.data": [1, "fish", 2, "fish"]
+}
+```
+
+> Note: currently, thanks to how JSON works, floating point values
+> like `1.0` that can be converted to an integer will end up dropping
+> the decimal point. (e.g. `1.0 => 1`)
+
+## Limitations
+
+- Arrays of Objects are currently untested.
+- Providing a series of Objects as input, not an an Array, may result
+  in a series of flattened Objects as output.
+
+## Building & Installing
+
+To get started you first need to have at least go 1.20 installed.
+
+Once you're ready to test out your transform live you need to:
+
+1. Make sure you have Redpanda running.
+2. Run `rpk transform build -- -scheduler=asyncify`.
+3. Create your topics via `rpk topic create`.
+4. Run `rpk transform deploy`.
+
+## Configuring
+
+The delimitter used defaults to `.` but may be changed by setting the
+`RP_FLATTEN_DELIM` environment variable. This is done during
+deployment:
+
+```
+$ rpk transform deploy --env-var "RP_FLATTEN_DELIM=-"
+```

--- a/data-transforms/flatten/README.md
+++ b/data-transforms/flatten/README.md
@@ -45,7 +45,7 @@ To get started you first need to have at least go 1.20 installed.
 Once you're ready to test out your transform live you need to:
 
 1. Make sure you have Redpanda running.
-2. Run `rpk transform build -- -scheduler=asyncify`.
+2. Run `rpk transform build`.
 3. Create your topics via `rpk topic create`.
 4. Run `rpk transform deploy`.
 

--- a/data-transforms/flatten/go.mod
+++ b/data-transforms/flatten/go.mod
@@ -1,0 +1,8 @@
+module flatten
+
+go 1.20
+
+require (
+	github.com/bcicen/jstream v1.0.1 // indirect
+	github.com/redpanda-data/redpanda/src/transform-sdk/go v0.0.0-20231128192633-fe2d537402e2 // indirect
+)

--- a/data-transforms/flatten/go.sum
+++ b/data-transforms/flatten/go.sum
@@ -1,0 +1,4 @@
+github.com/bcicen/jstream v1.0.1 h1:BXY7Cu4rdmc0rhyTVyT3UkxAiX3bnLpKLas9btbH5ck=
+github.com/bcicen/jstream v1.0.1/go.mod h1:9ielPxqFry7Y4Tg3j4BfjPocfJ3TbsRtXOAYXYmRuAQ=
+github.com/redpanda-data/redpanda/src/transform-sdk/go v0.0.0-20231128192633-fe2d537402e2 h1:SdaOGxCFQVyyBcUM5eTl19uBn1IPM10VnWEqMicDatg=
+github.com/redpanda-data/redpanda/src/transform-sdk/go v0.0.0-20231128192633-fe2d537402e2/go.mod h1:pLVlv4tasly/dKBIXo6UAXoeHtlqHL2+1c8BR90qD1g=

--- a/data-transforms/flatten/transform.go
+++ b/data-transforms/flatten/transform.go
@@ -17,7 +17,7 @@ func main() {
 	if !present {
 		delim = DELIM_DEFAULT
 	}
-	fmt.Println("Using delimitter: ", delim)
+	fmt.Println("using delimitter: ", delim)
 
 	buffer := bytes.NewBuffer(make([]byte, 1024))
 	fn := func(e redpanda.WriteEvent) ([]redpanda.Record, error) {
@@ -25,7 +25,6 @@ func main() {
 	}
 
 	redpanda.OnRecordWritten(fn)
-	fmt.Println("Registered flatten function")
 }
 
 // doTransform is where you read the record that was written, and then you can

--- a/data-transforms/flatten/transform.go
+++ b/data-transforms/flatten/transform.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/bcicen/jstream"
+	"github.com/redpanda-data/redpanda/src/transform-sdk/go"
+	"io"
+	"os"
+)
+
+const DELIM_KEY = "RP_FLATTEN_DELIM"
+const DELIM_DEFAULT = "."
+
+func main() {
+	delim, present := os.LookupEnv(DELIM_KEY)
+	if !present {
+		delim = DELIM_DEFAULT
+	}
+	fmt.Println("Using delimitter: ", delim)
+
+	buffer := bytes.NewBuffer(make([]byte, 1024))
+	fn := func(e redpanda.WriteEvent) ([]redpanda.Record, error) {
+		return doFlatten(e, buffer, delim)
+	}
+
+	redpanda.OnRecordWritten(fn)
+	fmt.Println("Registered flatten function")
+}
+
+// doTransform is where you read the record that was written, and then you can
+// return new records that will be written to the output topic
+func doFlatten(e redpanda.WriteEvent, buf *bytes.Buffer, delim string) ([]redpanda.Record, error) {
+	record := e.Record()
+
+	// Skip empty records.
+	if record.Value == nil || len(record.Value) == 0 {
+		return []redpanda.Record{}, nil
+	}
+
+	buf.Reset()
+
+	r := bytes.NewReader(record.Value)
+	err := Flatten(r, buf, delim)
+	if err != nil {
+		return []redpanda.Record{}, err
+	}
+
+	record.Value = buf.Bytes()
+	return []redpanda.Record{record}, err
+}
+
+func Flatten(r io.Reader, w io.Writer, delim string) error {
+	decoder := jstream.NewDecoder(r, 0)
+
+	// Iterate over pointers to jstream.MetaValues.
+	// n.b. this is a channel, btw
+	for mv := range decoder.ObjectAsKVS().Stream() {
+		kvs := mv.Value.(jstream.KVS)
+		fmt.Fprintln(w, "{")
+		for _, kv := range kvs {
+			descend(w, kv, 0, kv.Key, delim, true)
+		}
+		fmt.Fprintln(w, "\n}")
+	}
+	return nil
+}
+
+func descend(w io.Writer, kv jstream.KV, depth int, key string, delim string, first bool) {
+	if !first {
+		fmt.Fprintln(w, ",")
+	}
+
+	switch kv.Value.(type) {
+	case string:
+		fmt.Fprintf(w, "  \"%s\": \"%s\"", key, kv.Value)
+		break
+	case []interface{}:
+		// Somehow, this case doesn't match the jstream.KVS case.
+		// If it did, this would all break :D
+		fmt.Fprintf(w, "  \"%s\": [", key)
+		for i, v := range kv.Value.([]interface{}) {
+			if i > 0 {
+				fmt.Fprintf(w, ", ")
+			}
+			switch v.(type) {
+			case string:
+				fmt.Fprintf(w, "\"%s\"", v)
+				break
+			default:
+				fmt.Fprintf(w, "%v", v)
+			}
+		}
+		fmt.Fprintf(w, "]")
+		break
+	case jstream.KVS:
+		kvs := kv.Value.(jstream.KVS)
+		nextFirst := true
+		for _, kv := range kvs {
+			new_key := key + delim + kv.Key
+			descend(w, kv, depth+1, new_key, delim, nextFirst)
+			nextFirst = false
+		}
+		// fallthrough
+	default:
+		if kv.Value != nil {
+			fmt.Fprintf(w, "  \"%s\": %v", key, kv.Value)
+		} else {
+			fmt.Fprintf(w, "  \"%s\": null", key)
+		}
+	}
+}

--- a/data-transforms/flatten/transform.yaml
+++ b/data-transforms/flatten/transform.yaml
@@ -1,0 +1,4 @@
+name: flatten
+input-topic: ""
+output-topic: ""
+language: tinygo

--- a/data-transforms/flatten/transform.yaml
+++ b/data-transforms/flatten/transform.yaml
@@ -1,4 +1,4 @@
 name: flatten
 input-topic: ""
 output-topic: ""
-language: tinygo
+language: tinygo-with-goroutines

--- a/data-transforms/flatten/transform_test.go
+++ b/data-transforms/flatten/transform_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+var sampleJson = `{
+  "content": {
+    "id": 123,
+    "name": {
+      "first": "Dave",
+      "middle": null,
+      "last": "Voutila"
+    },
+    "data": [1, "fish", 2, "fish"]
+  }
+}
+`
+
+var flattenedJson = `{
+  "content.id": 123,
+  "content.name.first": "Dave",
+  "content.name.middle": null,
+  "content.name.last": "Voutila",
+  "content.data": [1, "fish", 2, "fish"]
+}
+`
+
+func TestJSONStream(t *testing.T) {
+	bufIn := bytes.NewBufferString(sampleJson)
+	bufOut := bytes.NewBuffer([]byte{})
+	err := Flatten(bufIn, bufOut, ".")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result := bufOut.String()
+
+	if strings.Compare(flattenedJson, result) != 0 {
+		t.Errorf("expected:\n%sgot:\n%s", flattenedJson, result)
+	}
+}


### PR DESCRIPTION
Based on the ["Flatten" Apache Kafka SMT](https://docs.confluent.io/platform/current/connect/transforms/flatten.html) for flattening nested JSON structures.

Requires building with "asyncify" scheduler, currently, because of the streaming JSON parser. (Looking to replace it with a streaming parser that doesn't use Go routines...but want to get this imported first.)