### PR TITLE
Add a GitOps example for deploying the Redpanda Helm Chart with Flux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@ rpk*
 # Go
 go.work*
 
+# Kubernetes
+kubernetes/gitops/flux-system/
+
 # Python
 __pycache__/
 env/

--- a/README.md
+++ b/README.md
@@ -12,9 +12,12 @@ Contributions are welcome. Just fork the repo (or submodule) and send a pull req
 
 | Project       | Description   |
 | ------------- | ------------- |
-| [`redpanda-edge-agent`](https://github.com/redpanda-data/redpanda-edge-agent) | Lightweight Internet of Things (IoT) agent that forwards events from the edge. |
-| [`data-transforms`](https://github.com/redpanda-data/redpanda-labs/tree/main/data-transforms) | Example topic data transforms powered by WebAssembly (Wasm). |
 | [`clients`](https://github.com/redpanda-data/redpanda-labs/clients) | A collection of Redpanda clients available in different programming languages. |
+| [`data-transforms`](https://github.com/redpanda-data/redpanda-labs/tree/main/data-transforms) | Example topic data transforms powered by WebAssembly (Wasm). |
+| [`redpanda-edge-agent`](https://github.com/redpanda-data/redpanda-edge-agent) | Lightweight Internet of Things (IoT) agent that forwards events from the edge. |
+| [`kubernetes`](https://github.com/redpanda-data/redpanda-labs/tree/main/kubernetes) | Examples of deploying and managing Redpanda in Kubernetes. |
+
+
 
 ## Update submodules
 

--- a/kubernetes/gitops/README.adoc
+++ b/kubernetes/gitops/README.adoc
@@ -1,0 +1,142 @@
+= Set Up GitOps for the Redpanda Helm Chart
+:description: This example uses Flux to deploy the Redpanda Helm chart on a local Kubernetes cluster.
+:page-interactive-example: https://play.instruqt.com/manage/redpanda/tracks/redpanda-k8s-gitops
+:page-category: Deployment, GitOps
+
+GitOps is a modern approach to managing and automating the deployment and provisioning process using Git as the single source of truth. It involves storing configuration files and deployment scripts in a Git repository, and then using automation tools to continuously monitor the repository for changes.
+
+This example uses Flux to deploy the Redpanda Helm chart on a local Kubernetes cluster. Flux is a toolkit for GitOps with Kubernetes clusters that supports the following:
+
+- *Version control for configurations*: You can track changes, collaborate, and revert to previous configurations if needed.
+- *Drift detection and remediation*: Flux continuously monitors the Redpanda cluster's state. If discrepancies are detected, Flux automatically remediates them to bring the Redpanda cluster back to the desired state.
+- *Collaboration and auditing*: Multiple team members can propose changes to Redpanda configurations through Git pull requests, enabling code reviews and discussions before changes are applied.
+
+== Prerequisites
+
+You must have the following:
+
+- https://github.com/signup[A GitHub account].
+
+- https://fluxcd.io/flux/installation/#install-the-flux-cli[The Flux CLI]
+
+- An understanding of the https://fluxcd.io/flux/concepts/[core concepts of Flux].
+
+- At least version 1.24 of https://kubernetes.io/docs/tasks/tools/[the kubectl CLI].
++
+[,bash]
+----
+kubectl version --client
+----
+- At least version 3.6.0 of https://helm.sh/docs/intro/install/[Helm].
++
+[,bash]
+----
+helm version
+----
+
+- https://kind.sigs.k8s.io/docs/user/quick-start/#installation[kind]
+
+- https://docs.docker.com/get-docker/[Docker]
+
+== Create a local Kubernetes cluster
+
+Create one master and three worker nodes (one worker node for each Redpanda broker).
+
+. Define a cluster in the `kind.yaml` configuration file:
++
+```bash
+cat <<EOF >kind.yaml
+---
+apiVersion: kind.x-k8s.io/v1alpha4
+kind: Cluster
+nodes:
+  - role: control-plane
+  - role: worker
+  - role: worker
+  - role: worker
+EOF
+```
+
+. Create the Kubernetes cluster from the configuration file:
++
+```bash
+kind create cluster --config kind.yaml
+```
+
+== Run the example
+
+Fork the `redpanda-examples` repository, and configure Flux to connect to your fork.
+
+. Fork the https://github.com/redpanda-data/redpanda-examples[`redpanda-data/redpanda-examples`] repository on GitHub.
+
+. Bootstrap Flux for your forked repository.
++
+[NOTE]
+====
+Make sure to do the following:
+
+- Provide Flux with your https://fluxcd.io/flux/installation/bootstrap/github/#github-pat[GitHub personal access token (PAT)].
+- Configure the `path` flag with the value `kubernetes/gitops`. This is the path where the example manifests are stored in the repository.
+====
++
+Here is an example of the bootstrap command:
++
+[,bash]
+----
+flux bootstrap github \
+  --token-auth \
+  --owner=<github-username> \
+  --repository=redpanda-examples \
+  --branch=main \
+  --path=./kubernetes/gitops \
+  --personal
+----
++
+Replace `<github-username>` with your GitHub username.
+
+The bootstrap script does the following:
+
+. Creates a deploy token and saves it as a Kubernetes Secret
+. Creates an empty GitHub project, if the project specified by `--repository` doesn't exist
+. Generates Flux definition files for your project
+. Commits the definition files to the specified branch
+. Applies the definition files to your cluster
+. Applies the manifests in `kubernetes/gitops` which deploy Redpanda and cert-manager
+
+After you run the script, Flux is ready to manage itself and any other resources you add to the GitHub project at the specified path.
+
+== Verify the deployment
+
+To verify that the deployment was successful, check the status of the HelmRelease resource:
+
+[,bash]
+----
+kubectl get helmrelease redpanda --namespace redpanda --watch
+----
+
+In a few minutes, you should see that the Helm install succeeded:
+
+[.no-copy]
+----
+NAME       AGE     READY   STATUS
+redpanda   3m23s   True    Helm install succeeded for release redpanda/redpanda.v1 with chart redpanda@5.7.5
+----
+
+== Manage updates
+
+To update Redpanda, modify the `redpanda-helm-release.yaml` manifest in your Git repository. You can configure the Helm chart in the `spec.values` field. For a description of all available configurations, see the https://docs.redpanda.com/current/reference/k-redpanda-helm-spec/[Redpanda Helm Chart Specification].
+
+When you push changes to GitHub, Flux automatically applies the updates to your Kubernetes cluster.
+
+== Delete the cluster
+
+To delete the Kubernetes cluster as well as all the Docker resources that kind created, run:
+
+[,bash]
+----
+kind delete cluster
+----
+
+== Suggested reading
+
+See the {page-interactive-example}[interactive examples] for setting up GitOps with the Redpanda Operator.

--- a/kubernetes/gitops/cert-manager-ns.yaml
+++ b/kubernetes/gitops/cert-manager-ns.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cert-manager

--- a/kubernetes/gitops/cert-manager-release.yaml
+++ b/kubernetes/gitops/cert-manager-release.yaml
@@ -1,0 +1,17 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: cert-manager
+  namespace: cert-manager
+spec:
+  interval: 1h
+  chart:
+    spec:
+      chart: cert-manager
+      version: "1.13.3"
+      sourceRef:
+        kind: HelmRepository
+        name: jetstack
+        namespace: flux-system
+  values:
+    installCRDs: true

--- a/kubernetes/gitops/cert-manager-repo.yaml
+++ b/kubernetes/gitops/cert-manager-repo.yaml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1beta1
+kind: HelmRepository
+metadata:
+  name: jetstack
+  namespace: flux-system
+spec:
+  interval: 1h
+  url: https://charts.jetstack.io

--- a/kubernetes/gitops/redpanda-helm-release.yaml
+++ b/kubernetes/gitops/redpanda-helm-release.yaml
@@ -1,0 +1,24 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: redpanda
+  namespace: redpanda
+spec:
+  dependsOn:
+    - name: cert-manager
+      namespace: cert-manager
+  interval: 5m
+  chart:
+    spec:
+      chart: redpanda
+      version: "5.7.*"
+      sourceRef:
+        kind: HelmRepository
+        name: redpanda
+        namespace: redpanda
+      interval: 1m
+  values:
+    statefulset:
+      initContainers:
+        setDataDirOwnership:
+          enabled: true

--- a/kubernetes/gitops/redpanda-ns.yaml
+++ b/kubernetes/gitops/redpanda-ns.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: redpanda

--- a/kubernetes/gitops/redpanda-repo.yaml
+++ b/kubernetes/gitops/redpanda-repo.yaml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: redpanda
+  namespace: redpanda
+spec:
+  interval: 5m0s
+  url: https://charts.redpanda.com/

--- a/kubernetes/kind/kind.yaml
+++ b/kubernetes/kind/kind.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kind.x-k8s.io/v1alpha4
+kind: Cluster
+nodes:
+  - role: control-plane
+  - role: worker
+  - role: worker
+  - role: worker


### PR DESCRIPTION
This PR has already been approved here: https://github.com/redpanda-data/redpanda-examples/pull/38. We moved it to this repo because `redpanda-examples` is due to be discontinued as mentioned here: https://github.com/redpanda-data/redpanda-examples/issues/37.

Fixes https://github.com/redpanda-data/documentation-private/issues/1647

We will pull this into the docs site after https://github.com/redpanda-data/documentation-private/issues/1993 is completed.