### PR TITLE
Use dev mode for Docker Compose deployments

### DIFF
--- a/data-transforms/flatten/docker-compose.yml
+++ b/data-transforms/flatten/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     - redpanda
     - start
     - --mode dev-container
+    - --smp 1
     - --kafka-addr
     - PLAINTEXT://0.0.0.0:9092,OUTSIDE://0.0.0.0:9093
     - --advertise-kafka-addr

--- a/data-transforms/iss_demo/docker-compose.yml
+++ b/data-transforms/iss_demo/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     - redpanda
     - start
     - --mode dev-container
+    - --smp 1
     - --kafka-addr
     - PLAINTEXT://0.0.0.0:9092,OUTSIDE://0.0.0.0:9093
     - --advertise-kafka-addr

--- a/data-transforms/redaction/demo/docker-compose.yml
+++ b/data-transforms/redaction/demo/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     - redpanda
     - start
     - --mode dev-container
+    - --smp 1
     - --memory
     - 4000M
     - --seeds

--- a/data-transforms/regex/docker-compose.yml
+++ b/data-transforms/regex/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     - redpanda
     - start
     - --mode dev-container
+    - --smp 1
     - --kafka-addr
     - PLAINTEXT://0.0.0.0:9092,OUTSIDE://0.0.0.0:9093
     - --advertise-kafka-addr

--- a/data-transforms/to_avro/docker-compose.yml
+++ b/data-transforms/to_avro/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     - redpanda
     - start
     - --mode dev-container
+    - --smp 1
     - --kafka-addr
     - PLAINTEXT://0.0.0.0:9092,OUTSIDE://0.0.0.0:9093
     - --advertise-kafka-addr

--- a/docker-compose/cdc/mysql-json/docker-compose.yml
+++ b/docker-compose/cdc/mysql-json/docker-compose.yml
@@ -21,7 +21,10 @@ services:
     container_name: redpanda
     command:
       - redpanda start
+      # Mode dev-container uses well-known configuration properties for development in containers.
       - --mode dev-container
+      # Tells Seastar (the framework Redpanda uses under the hood) to use 1 core on the system.
+      - --smp 1
       - --kafka-addr internal://0.0.0.0:9092,external://0.0.0.0:19092
       # Address the broker advertises to clients that connect to the Kafka API.
       # Use the internal addresses to connect to the Redpanda brokers

--- a/docker-compose/cdc/postgres-json/docker-compose.yml
+++ b/docker-compose/cdc/postgres-json/docker-compose.yml
@@ -25,7 +25,10 @@ services:
     container_name: redpanda
     command:
       - redpanda start
+      # Mode dev-container uses well-known configuration properties for development in containers.
       - --mode dev-container
+      # Tells Seastar (the framework Redpanda uses under the hood) to use 1 core on the system.
+      - --smp 1
       - --kafka-addr internal://0.0.0.0:9092,external://0.0.0.0:19092
       # Address the broker advertises to clients that connect to the Kafka API.
       # Use the internal addresses to connect to the Redpanda brokers

--- a/docker-compose/console-plain-login/docker-compose.yml
+++ b/docker-compose/console-plain-login/docker-compose.yml
@@ -11,7 +11,10 @@ services:
     image: docker.redpanda.com/redpandadata/redpanda:v${REDPANDA_VERSION:?Set a Redpanda version}
     command:
       - redpanda start
+      # Mode dev-container uses well-known configuration properties for development in containers.
       - --mode dev-container
+      # Tells Seastar (the framework Redpanda uses under the hood) to use 1 core on the system.
+      - --smp 1
       - --kafka-addr internal://0.0.0.0:9092,external://0.0.0.0:19092
       # Address the broker advertises to clients that connect to the Kafka API.
       # Use the internal addresses to connect to the Redpanda brokers

--- a/docker-compose/owl-shop/docker-compose.yml
+++ b/docker-compose/owl-shop/docker-compose.yml
@@ -24,7 +24,10 @@ services:
       # Redpanda brokers use the RPC API to communicate with each other internally.
       - --rpc-addr redpanda:33145
       - --advertise-rpc-addr redpanda:33145
+      # Mode dev-container uses well-known configuration properties for development in containers.
       - --mode dev-container
+      # Tells Seastar (the framework Redpanda uses under the hood) to use 1 core on the system.
+      - --smp 1
     ports:
       - 18081:18081
       - 18082:18082

--- a/docker-compose/single-broker/docker-compose.yml
+++ b/docker-compose/single-broker/docker-compose.yml
@@ -26,7 +26,8 @@ services:
       - --advertise-rpc-addr redpanda-0:33145
       # Mode dev-container uses well-known configuration properties for development in containers.
       - --mode dev-container
-      # Enable logs for debugging.
+      # Tells Seastar (the framework Redpanda uses under the hood) to use 1 core on the system.
+      - --smp 1
       - --default-log-level=info
     image: docker.redpanda.com/redpandadata/redpanda:v${REDPANDA_VERSION:?Set a Redpanda version}
     container_name: redpanda-0

--- a/docker-compose/three-brokers/docker-compose.yml
+++ b/docker-compose/three-brokers/docker-compose.yml
@@ -28,7 +28,8 @@ services:
       - --advertise-rpc-addr redpanda-0:33145
       # Mode dev-container uses well-known configuration properties for development in containers.
       - --mode dev-container
-      # Enable logs for debugging.
+      # Tells Seastar (the framework Redpanda uses under the hood) to use 1 core on the system.
+      - --smp 1
       - --default-log-level=info
     image: docker.redpanda.com/redpandadata/redpanda:v${REDPANDA_VERSION:?Set a Redpanda version}
     container_name: redpanda-0
@@ -53,6 +54,7 @@ services:
       - --rpc-addr redpanda-1:33145
       - --advertise-rpc-addr redpanda-1:33145
       - --mode dev-container
+      - --smp 1
       - --default-log-level=info
       - --seeds redpanda-0:33145
     image: docker.redpanda.com/redpandadata/redpanda:v${REDPANDA_VERSION:?Set a Redpanda version}
@@ -80,6 +82,7 @@ services:
       - --rpc-addr redpanda-2:33145
       - --advertise-rpc-addr redpanda-2:33145
       - --mode dev-container
+      - --smp 1
       - --default-log-level=info
       - --seeds redpanda-0:33145
     image: docker.redpanda.com/redpandadata/redpanda:v${REDPANDA_VERSION:?Set a Redpanda version}


### PR DESCRIPTION
Fixes https://github.com/redpanda-data/documentation-private/issues/2272

Does not remove `--smp` to avoid Redpanda from taking all available cores. For the internal discussion see https://redpandadata.slack.com/archives/C01ND4SVB6Z/p1706823718270109