### PR TITLE
data-transforms/jq: specify you need to install wasi target

### DIFF
--- a/data-transforms/jq/README.adoc
+++ b/data-transforms/jq/README.adoc
@@ -24,6 +24,7 @@ See the jq manual for more information on how to write a filter: https://jqlang.
 You must have the following:
 
 - At least version 1.75 of https://rustup.rs/[Rust^] installed on your host machine.
+- The rustc `wasm32-wasi` target installed via `rustup target add wasm32-wasi`
 - link:https://docs.redpanda.com/current/get-started/rpk-install/[Install `rpk`] on your host machine.
 - https://docs.docker.com/compose/install/[Docker and Docker Compose] installed on your host machine.
 

--- a/data-transforms/jq/README.adoc
+++ b/data-transforms/jq/README.adoc
@@ -24,7 +24,12 @@ See the jq manual for more information on how to write a filter: https://jqlang.
 You must have the following:
 
 - At least version 1.75 of https://rustup.rs/[Rust^] installed on your host machine.
-- The rustc `wasm32-wasi` target installed via `rustup target add wasm32-wasi`
+- The Wasm target for Rust installed. To install this target, run the following:
++
+[source,bash]
+----
+rustup target add wasm32-wasi
+----
 - link:https://docs.redpanda.com/current/get-started/rpk-install/[Install `rpk`] on your host machine.
 - https://docs.docker.com/compose/install/[Docker and Docker Compose] installed on your host machine.
 


### PR DESCRIPTION
Normally we install this target for you in `rpk transform init --language=rust` but if you just run this command without that you need to have the wasi target installed for rustc
