### PR TITLE
Adds missing config file

### DIFF
--- a/docker-compose/cdc/postgres-json/docker-compose.yml
+++ b/docker-compose/cdc/postgres-json/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     ports:
       - 5432:5432
     healthcheck:
-      test: "pg_isready -U postgresuser -d shipment_db"
+      test: "pg_isready -U postgresuser -d pandashop"
       interval: 2s
       timeout: 20s
       retries: 10
@@ -18,8 +18,9 @@ services:
       - POSTGRES_PASSWORD=postgrespw
       - POSTGRES_DB=pandashop
       - PGPASSWORD=postgrespw
-    volumes:
-      - ./data:/docker-entrypoint-initdb.d
+    configs:
+      - source: init.postgres
+        target: /docker-entrypoint-initdb.d/postgres_bootstrap.sql
   redpanda:
     image: docker.redpanda.com/redpandadata/redpanda:v${REDPANDA_VERSION:?Set a Redpanda version}
     container_name: redpanda
@@ -67,3 +68,20 @@ services:
     depends_on: [postgres, redpanda]
     ports:
       - 8083:8083
+configs:
+  init.postgres:
+    content: |
+      -- Create the orders table
+      create table orders (
+          order_id serial primary key,
+          customer_id int,
+          total float,
+          created_at timestamp default now()
+      );
+
+      -- Populate it with a few values
+      insert into orders(customer_id, total) values (1,50);
+      insert into orders(customer_id, total) values (2,100);
+      insert into orders(customer_id, total) values (2,50);
+      insert into orders(customer_id, total) values (3,10);
+      insert into orders(customer_id, total) values (4,90);


### PR DESCRIPTION
The docs for this lab mention the Postgres bootstrap file, but do not provide instructions for downloading it. This PR adds a `configs` section to the `docker-compose.yml` and mounts the config in the right place.

It also corrects the healthcheck for Postgres, it was looking for the wrong database.

## Original log from the Postgres service

```
postgres  | PostgreSQL init process complete; ready for start up.
postgres  |
postgres  | 2024-04-30 18:01:45.268 UTC [1] LOG:  starting PostgreSQL 16.2 (Debian 16.2-1.pgdg110+2) on aarch64-unknown-linux-gnu, compiled by gcc (Debian 10.2.1-6) 10.2.1 20210110, 64-bit
postgres  | 2024-04-30 18:01:45.268 UTC [1] LOG:  listening on IPv4 address "0.0.0.0", port 5432
postgres  | 2024-04-30 18:01:45.268 UTC [1] LOG:  listening on IPv6 address "::", port 5432
postgres  | 2024-04-30 18:01:45.271 UTC [1] LOG:  listening on Unix socket "/var/run/postgresql/.s.PGSQL.5432"
postgres  | 2024-04-30 18:01:45.272 UTC [64] LOG:  database system was shut down at 2024-04-30 18:01:45 UTC
postgres  | 2024-04-30 18:01:45.274 UTC [1] LOG:  database system is ready to accept connections
postgres  | 2024-04-30 18:01:46.332 UTC [75] FATAL:  database "shipment_db" does not exist
```

## Updated log showing the creation of the `orders` table in the `pandashop` DB

```
postgres  | 2024-04-30 18:47:15.426 UTC [48] LOG:  database system is ready to accept connections
postgres  |  done
postgres  | server started
postgres  | CREATE DATABASE
postgres  |
postgres  |
postgres  | /usr/local/bin/docker-entrypoint.sh: sourcing /docker-entrypoint-initdb.d/init-permissions.sh
postgres  |
postgres  | /usr/local/bin/docker-entrypoint.sh: running /docker-entrypoint-initdb.d/postgres_bootstrap.sql
postgres  | CREATE TABLE
postgres  | INSERT 0 1
postgres  | INSERT 0 1
postgres  | INSERT 0 1
postgres  | INSERT 0 1
postgres  | INSERT 0 1
postgres  |
postgres  |
postgres  | 2024-04-30 18:47:15.591 UTC [48] LOG:  received fast shutdown request
postgres  | waiting for server to shut down....2024-04-30 18:47:15.592 UTC [48] LOG:  aborting any active transactions
postgres  | 2024-04-30 18:47:15.593 UTC [48] LOG:  background worker "logical replication launcher" (PID 54) exited with exit code 1
postgres  | 2024-04-30 18:47:15.593 UTC [49] LOG:  shutting down
postgres  | 2024-04-30 18:47:15.596 UTC [49] LOG:  checkpoint starting: shutdown immediate
postgres  | 2024-04-30 18:47:15.618 UTC [49] LOG:  checkpoint complete: wrote 932 buffers (5.7%); 0 WAL file(s) added, 0 removed, 0 recycled; write=0.007 s, sync=0.014 s, total=0.025 s; sync files=304, longest=0.006 s, average=0.001 s; distance=4272 kB, estimate=4272 kB; lsn=0/19DA968, redo lsn=0/19DA968
postgres  | 2024-04-30 18:47:15.620 UTC [48] LOG:  database system is shut down
postgres  |  done
postgres  | server stopped
postgres  |
postgres  | PostgreSQL init process complete; ready for start up.
postgres  |
postgres  | 2024-04-30 18:47:15.701 UTC [1] LOG:  starting PostgreSQL 16.2 (Debian 16.2-1.pgdg110+2) on aarch64-unknown-linux-gnu, compiled by gcc (Debian 10.2.1-6) 10.2.1 20210110, 64-bit
postgres  | 2024-04-30 18:47:15.701 UTC [1] LOG:  listening on IPv4 address "0.0.0.0", port 5432
postgres  | 2024-04-30 18:47:15.701 UTC [1] LOG:  listening on IPv6 address "::", port 5432
postgres  | 2024-04-30 18:47:15.713 UTC [1] LOG:  listening on Unix socket "/var/run/postgresql/.s.PGSQL.5432"
postgres  | 2024-04-30 18:47:15.721 UTC [66] LOG:  database system was shut down at 2024-04-30 18:47:15 UTC
postgres  | 2024-04-30 18:47:15.722 UTC [1] LOG:  database system is ready to accept connections
```

