### PR TITLE
fix Postgres service healthcheck

### DIFF
--- a/docker-compose/cdc/postgres-json/docker-compose.yml
+++ b/docker-compose/cdc/postgres-json/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     ports:
       - 5432:5432
     healthcheck:
-      test: "pg_isready -U postgresuser -d shipment_db"
+      test: "pg_isready -U postgresuser -d pandashop"
       interval: 2s
       timeout: 20s
       retries: 10


### PR DESCRIPTION
The Postgres service logs were full of errors as the healthcheck was looking for the DB `shipment_db` instead of pandashop:

```
postgres  | 2024-04-30 18:02:06.886 UTC [154] FATAL:  database "shipment_db" does not exist
postgres  | 2024-04-30 18:02:08.950 UTC [162] FATAL:  database "shipment_db" does not exist
postgres  | 2024-04-30 18:02:11.000 UTC [170] FATAL:  database "shipment_db" does not exist
postgres  | 2024-04-30 18:02:13.060 UTC [178] FATAL:  database "shipment_db" does not exist
postgres  | 2024-04-30 18:02:15.109 UTC [186] FATAL:  database "shipment_db" does not exist
postgres  | 2024-04-30 18:02:17.180 UTC [195] FATAL:  database "shipment_db" does not exist
postgres  | 2024-04-30 18:02:19.245 UTC [203] FATAL:  database "shipment_db" does not exist
postgres  | 2024-04-30 18:02:21.309 UTC [211] FATAL:  database "shipment_db" does not exist
postgres  | 2024-04-30 18:02:23.373 UTC [219] FATAL:  database "shipment_db" does not exist
postgres  | 2024-04-30 18:02:25.442 UTC [227] FATAL:  database "shipment_db" does not exist
```