### PR TITLE
Fix Owl Shop lab

### DIFF
--- a/docker-compose/owl-shop/docker-compose.yml
+++ b/docker-compose/owl-shop/docker-compose.yml
@@ -89,8 +89,9 @@ services:
           brokers: "redpanda:9092"
     depends_on:
       - redpanda
+      - connect
   connect:
-    image: docker.redpanda.com/redpandadata/connectors:latest
+    image: docker.redpanda.com/redpandadata/connectors:v1.0.23
     hostname: connect
     container_name: connect
     networks:


### PR DESCRIPTION
The Docker Compose file had the following issues:

- The `owl-shop` service logged "connection refused" errors when connecting to the Redpanda broker. This was due to an incorrect service startup order in our Docker Compose configuration.
- The latest version of the connect Docker image was not compatible with older CPUs, as it required CPU features that are part of the `x86-64-v2` architecture level, which our current hardware does not support. This resulted in a "Fatal glibc error: CPU does not support x86-64-v2" error during container startup.

To fix the issues, we:

- **Adjusted service dependencies**: The `owl-shop` service now waits for `connect`, which itself waits for `redpanda`. This guarantees that all services are ready in the proper order.
- **Pinned the connectors image version**: The `connect` Docker image is now pinned to an older version (1.0.23), which is compatible with older hardware's CPU features, avoiding the glibc compatibility issue.