### PR TITLE
[BugFix] Flatten Transformer No working as intended

### DIFF
--- a/data-transforms/flatten/transform.go
+++ b/data-transforms/flatten/transform.go
@@ -60,7 +60,7 @@ func Flatten(r io.Reader, w io.Writer, delim string) error {
 		fmt.Fprintln(w, "{")
 		for index, kv := range kvs {
 			isLastElement := len(kvs) - 1 == index
-			descend(w, kv, 0, kv.Key, delim, false)
+			descend(w, kv, 0, kv.Key, delim)
 			if ! isLastElement {
 				fmt.Fprint(w, ",\n")
 			}
@@ -70,7 +70,7 @@ func Flatten(r io.Reader, w io.Writer, delim string) error {
 	return nil
 }
 
-func descend(w io.Writer, kv jstream.KV, depth int, key string, delim string, isLastSubElement bool) {
+func descend(w io.Writer, kv jstream.KV, depth int, key string, delim string) {
 
 	switch kv.Value.(type) {
 	case string:
@@ -97,10 +97,15 @@ func descend(w io.Writer, kv jstream.KV, depth int, key string, delim string, is
 		break
 	case jstream.KVS:
 		kvs := kv.Value.(jstream.KVS)
+		if len(kvs) == 0 {
+			fmt.Fprintf(w, "  \"%s\": {}", key)
+			return
+		}
+
 		for index, kv := range kvs {
 			new_key := key + delim + kv.Key
 			var isLastSubElementLocal = len(kvs) - 1 == index
-			descend(w, kv, depth+1, new_key, delim, isLastSubElementLocal)
+			descend(w, kv, depth+1, new_key, delim)
 			if ! isLastSubElementLocal {
 				fmt.Fprint(w, ",\n")
 			}
@@ -112,6 +117,5 @@ func descend(w io.Writer, kv jstream.KV, depth int, key string, delim string, is
 		} else {
 			fmt.Fprintf(w, "  \"%s\": null", key)
 		}
-
 	}
 }

--- a/data-transforms/flatten/transform_test.go
+++ b/data-transforms/flatten/transform_test.go
@@ -33,6 +33,27 @@ var sampleJsonWithRootElements = `{
 }
 `
 
+var complexJson = `{
+  "id": 1234,
+  "content": {
+    "id": 123,
+    "name": {
+      "first": "Dave",
+      "middle": null
+    }
+  },
+  "data": [1, "fish", 2, "fish"],
+  "more_data": {
+    "id": 123,
+    "name": {
+      "first": "Bob",
+      "middle": "Jr"
+    }
+  },
+  "content": "test"
+}
+`
+
 var newFlattenedJson = `{
   "some_content": "test",
   "id:": 1234,
@@ -49,6 +70,19 @@ var flattenedJson = `{
   "content.name.middle": null,
   "content.name.last": "Voutila",
   "content.data": [1, "fish", 2, "fish"]
+}
+`
+
+var flattenedComplexJson = `{
+  "id": 1234,
+  "content.id": 123,
+  "content.name.first": "Dave",
+  "content.name.middle": null,
+  "data": [1, "fish", 2, "fish"],
+  "more_data.id": 123,
+  "more_data.name.first": "Bob",
+  "more_data.name.middle": "Jr",
+  "content": "test"
 }
 `
 
@@ -80,5 +114,22 @@ func TestJsonStreamWithRootElements(t *testing.T) {
 
   if strings.Compare(newFlattenedJson, result) != 0 {
     t.Errorf("expected:\n%sgot:\n%s", newFlattenedJson, result)
+  }
+}
+
+
+func TestComplexJsonStream(t *testing.T) {
+  bufIn := bytes.NewBufferString(complexJson)
+  bufOut := bytes.NewBuffer([]byte{})
+
+  err := Flatten(bufIn, bufOut, ".")
+  if err != nil {
+    t.Fatal(err)
+  }
+
+  result := bufOut.String()
+
+  if strings.Compare(flattenedComplexJson, result) != 0 {
+    t.Errorf("expected:\n%sgot:\n%s", flattenedComplexJson, result)
   }
 }

--- a/data-transforms/flatten/transform_test.go
+++ b/data-transforms/flatten/transform_test.go
@@ -19,6 +19,30 @@ var sampleJson = `{
 }
 `
 
+var sampleJsonWithRootElements = `{
+  "some_content": "test",
+  "id:": 1234,
+  "content": {
+    "id": 123,
+    "name": {
+      "first": "Dave",
+      "middle": null,
+      "last": "Voutila"
+    }
+  }
+}
+`
+
+var newFlattenedJson = `{
+  "some_content": "test",
+  "id:": 1234,
+  "content.id": 123,
+  "content.name.first": "Dave",
+  "content.name.middle": null,
+  "content.name.last": "Voutila"
+}
+`
+
 var flattenedJson = `{
   "content.id": 123,
   "content.name.first": "Dave",
@@ -41,4 +65,20 @@ func TestJSONStream(t *testing.T) {
 	if strings.Compare(flattenedJson, result) != 0 {
 		t.Errorf("expected:\n%sgot:\n%s", flattenedJson, result)
 	}
+}
+
+func TestJsonStreamWithRootElements(t *testing.T) {
+  bufIn := bytes.NewBufferString(sampleJsonWithRootElements)
+  bufOut := bytes.NewBuffer([]byte{})
+
+  err := Flatten(bufIn, bufOut, ".")
+  if err != nil {
+    t.Fatal(err)
+  }
+
+  result := bufOut.String()
+
+  if strings.Compare(newFlattenedJson, result) != 0 {
+    t.Errorf("expected:\n%sgot:\n%s", newFlattenedJson, result)
+  }
 }

--- a/data-transforms/flatten/transform_test.go
+++ b/data-transforms/flatten/transform_test.go
@@ -33,7 +33,7 @@ var sampleJsonWithRootElements = `{
 }
 `
 
-var complexJson = `{
+var sampleComplexJson = `{
   "id": 1234,
   "content": {
     "id": 123,
@@ -45,14 +45,18 @@ var complexJson = `{
   "data": [1, "fish", 2, "fish"],
   "more_data": {
     "id": 123,
+    "empty": {},
     "name": {
       "first": "Bob",
       "middle": "Jr"
     }
   },
-  "content": "test"
+  "content": "test",
+  "empty_again": {}
 }
 `
+
+
 
 var newFlattenedJson = `{
   "some_content": "test",
@@ -80,9 +84,11 @@ var flattenedComplexJson = `{
   "content.name.middle": null,
   "data": [1, "fish", 2, "fish"],
   "more_data.id": 123,
+  "more_data.empty": {},
   "more_data.name.first": "Bob",
   "more_data.name.middle": "Jr",
-  "content": "test"
+  "content": "test",
+  "empty_again": {}
 }
 `
 
@@ -119,7 +125,7 @@ func TestJsonStreamWithRootElements(t *testing.T) {
 
 
 func TestComplexJsonStream(t *testing.T) {
-  bufIn := bytes.NewBufferString(complexJson)
+  bufIn := bytes.NewBufferString(sampleComplexJson)
   bufOut := bytes.NewBuffer([]byte{})
 
   err := Flatten(bufIn, bufOut, ".")


### PR DESCRIPTION
Hello RedPanda community!

I was using your Flatten transformation example. I noticed attributes to the root didn't have the expected `,\n` at the end.

### Before:
```json
{
  "some_content": "test" "id:": 1234 "content.id": 123,
  "content.name.first": "Dave",
  "content.name.middle": null,
  "content.name.last": "Voutila"
}
```

### After

```json
{
  "some_content": "test",
  "id:": 1234,
  "content.id": 123,
  "content.name.first": "Dave",
  "content.name.middle": null,
  "content.name.last": "Voutila"
}
```