### PR TITLE
BugFix :: JSON Flatten is unable to handle a list of json objects

### DIFF
--- a/data-transforms/flatten/transform.go
+++ b/data-transforms/flatten/transform.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/bcicen/jstream"
 	"github.com/redpanda-data/redpanda/src/transform-sdk/go/transform"
@@ -71,7 +72,9 @@ func descend(w io.Writer, kv jstream.KV, depth int, key string, delim string) {
 
 	switch kv.Value.(type) {
 	case string:
-		fmt.Fprintf(w, "  \"%s\": \"%s\"", key, kv.Value)
+		stringValue := kv.Value.(string)
+		stringValue = strings.Replace(stringValue, "\n", " ", -1)
+		fmt.Fprintf(w, "  \"%s\": \"%s\"", key, stringValue)
 		return
 	case []interface{}:
 		isNodeFlattened := flattenListOfJsonObjects(w, kv, depth, key, delim)
@@ -82,7 +85,9 @@ func descend(w io.Writer, kv jstream.KV, depth int, key string, delim string) {
 		for index, v := range kv.Value.([]interface{}) {
 			switch v.(type) {
 			case string:
-				fmt.Fprintf(w, "\"%s\"", v)
+				stringValue := v.(string)
+				stringValue = strings.Replace(stringValue, "\n", " ", -1)
+				fmt.Fprintf(w, "\"%s\"", stringValue)
 			default:
 				fmt.Fprintf(w, "%v", v)
 			}

--- a/data-transforms/flatten/transform.go
+++ b/data-transforms/flatten/transform.go
@@ -115,3 +115,26 @@ func handleLastElement(w io.Writer, listSize int, index int, endingString string
 		fmt.Fprintf(w, "%s", endingString)
 	}
 }
+
+
+func flattenListOfJsonObjects(w io.Writer, kv jstream.KV, depth int, key string, delim string) bool {
+	isNodeFlattened := false
+	for parent_index, v := range kv.Value.([]interface{}) {
+		switch v.(type) {
+		case jstream.KVS:
+			isNodeFlattened = true
+			kvs := v.(jstream.KVS)
+
+			for index, kv := range kvs {
+				new_key := key + delim + fmt.Sprint(parent_index) + delim + kv.Key
+				descend(w, kv, depth+1, new_key, delim)
+				handleLastElement(w, len(kvs), index, ",\n")
+			}
+			handleLastElement(w, len(kv.Value.([]interface{})), parent_index, ",\n")
+
+		default:
+			return isNodeFlattened
+		}
+	}
+	return isNodeFlattened
+}

--- a/data-transforms/flatten/transform.go
+++ b/data-transforms/flatten/transform.go
@@ -119,3 +119,11 @@ func descend(w io.Writer, kv jstream.KV, depth int, key string, delim string) {
 		}
 	}
 }
+
+
+func handleLastElement(w io.Writer, listSize int, index int, endingString string){
+	var isLastSubElementLocal = listSize - 1 == index
+	if ! isLastSubElementLocal {
+		fmt.Fprintf(w, "%s", endingString)
+	}
+}

--- a/data-transforms/flatten/transform.go
+++ b/data-transforms/flatten/transform.go
@@ -75,7 +75,9 @@ func descend(w io.Writer, kv jstream.KV, depth int, key string, delim string) {
 		return
 	case []interface{}:
 		isNodeFlattened := flattenListOfJsonObjects(w, kv, depth, key, delim)
-		// If it did, this would all break :D
+		if isNodeFlattened {
+			return
+		}
 		fmt.Fprintf(w, "  \"%s\": [", key)
 		for index, v := range kv.Value.([]interface{}) {
 			switch v.(type) {

--- a/data-transforms/flatten/transform.go
+++ b/data-transforms/flatten/transform.go
@@ -72,7 +72,7 @@ func descend(w io.Writer, kv jstream.KV, depth int, key string, delim string) {
 	switch kv.Value.(type) {
 	case string:
 		fmt.Fprintf(w, "  \"%s\": \"%s\"", key, kv.Value)
-		break
+		return
 	case []interface{}:
 		isNodeFlattened := flattenListOfJsonObjects(w, kv, depth, key, delim)
 		// If it did, this would all break :D
@@ -81,14 +81,12 @@ func descend(w io.Writer, kv jstream.KV, depth int, key string, delim string) {
 			switch v.(type) {
 			case string:
 				fmt.Fprintf(w, "\"%s\"", v)
-				break
 			default:
 				fmt.Fprintf(w, "%v", v)
 			}
 			handleLastElement(w, len(kv.Value.([]interface{})), index, ", ")
 		}
 		fmt.Fprintf(w, "]")
-		break
 	case jstream.KVS:
 		kvs := kv.Value.(jstream.KVS)
 		if len(kvs) == 0 {

--- a/data-transforms/flatten/transform_test.go
+++ b/data-transforms/flatten/transform_test.go
@@ -40,7 +40,17 @@ var sampleComplexJson = `{
     "name": {
       "first": "Dave",
       "middle": null
-    }
+    },
+    "addresses": [
+      {
+        "street":"someStreet",
+        "appartments":[]
+      },
+      {
+        "street":"someOtherStreet",
+        "appartments":[ 1, 2, 3, 4 ]
+      }
+    ]
   },
   "data": [1, "fish", 2, "fish"],
   "more_data": {
@@ -82,6 +92,10 @@ var flattenedComplexJson = `{
   "content.id": 123,
   "content.name.first": "Dave",
   "content.name.middle": null,
+  "content.addresses.0.street": "someStreet",
+  "content.addresses.0.appartments": [],
+  "content.addresses.1.street": "someOtherStreet",
+  "content.addresses.1.appartments": [1, 2, 3, 4],
   "data": [1, "fish", 2, "fish"],
   "more_data.id": 123,
   "more_data.empty": {},

--- a/data-transforms/flatten/transform_test.go
+++ b/data-transforms/flatten/transform_test.go
@@ -35,6 +35,7 @@ var sampleJsonWithRootElements = `{
 
 var sampleComplexJson = `{
   "id": 1234,
+  "this": "is\na\nstring",
   "content": {
     "id": 123,
     "name": {
@@ -89,6 +90,7 @@ var flattenedJson = `{
 
 var flattenedComplexJson = `{
   "id": 1234,
+  "this": "is a string",
   "content.id": 123,
   "content.name.first": "Dave",
   "content.name.middle": null,


### PR DESCRIPTION
Hello! 

It is me again! 

I noticed the example couldn't handle lists of JSON objects as well. I fixed it, and I made quite a mess last time I contributed, so I cleaned behind myself :wink: .

As you will be able to see in my example below, I went for a common way to annotate the element that is part of a list by identifying it with the index of the element of the list.

Example:

Before:
```json
{
  "id": 1234,
  "content": {
    "id": 123,
    "name": {
      "first": "Dave",
      "middle": null
    },
    "addresses": [
      {
        "street":"someStreet",
        "appartments":[]
      },
      {
        "street":"someOtherStreet",
        "appartments":[ 1, 2, 3, 4 ]
      }
    ]
  },
  "data": [1, "fish", 2, "fish"],
  "more_data": {
    "id": 123,
    "empty": {},
    "name": {
      "first": "Bob",
      "middle": "Jr"
    }
  },
  "content": "test",
  "empty_again": {}
}
```

After:
```json
{
  "id": 1234,
  "content.id": 123,
  "content.name.first": "Dave",
  "content.name.middle": null,
  "content.addresses.0.street": "someStreet",
  "content.addresses.0.appartments": [],
  "content.addresses.1.street": "someOtherStreet",
  "content.addresses.1.appartments": [1, 2, 3, 4],
  "data": [1, "fish", 2, "fish"],
  "more_data.id": 123,
  "more_data.empty": {},
  "more_data.name.first": "Bob",
  "more_data.name.middle": "Jr",
  "content": "test",
  "empty_again": {}
}
```


Thank you :smile: 