### PR TITLE
Rename component to Labs

### DIFF
--- a/clients/docs/antora.yml
+++ b/clients/docs/antora.yml
@@ -1,3 +1,3 @@
 name: redpanda-labs
-title: Redpanda Labs
+title: Labs
 version: ~

--- a/docs/CONTRIBUTING.adoc
+++ b/docs/CONTRIBUTING.adoc
@@ -33,9 +33,6 @@ If you want to publish your README content on the Redpanda docs site, you can sy
 
 Labs can be published on the https://docs.redpanda.com/redpanda-labs/[official Redpanda docs site] by following a specific directory structure for Antora. When you publish labs on the Redpanda docs site, they are automatically indexed to make them searchable through Algolia and to enhance discoverability.
 
-.Landing page for Redpanda Labs in the docs
-image::docs-labs.png[link=https://docs.redpanda.com/redpanda-labs/]
-
 Documentation metadata, defined in the <<attributes, Asciidoc header>> of each page, generates search filters and automates cross-linking between related documents. Example metadata includes:
 
 [,yaml]
@@ -45,19 +42,13 @@ Documentation metadata, defined in the <<attributes, Asciidoc header>> of each p
 :env-docker: true
 ----
 
-If a lab page falls into the same categories as a doc page and the deployment types of both the doc page and the lab page matches, those pages are considered related and cross-links are automatically added.
-
-.Crosslinks on a lab page
-image::docs-lab.png[link=https://docs.redpanda.com/redpanda-labs/]
-
-.Crosslinks on a docs page
-image::docs-link-to-labs.png[link=https://docs.redpanda.com/redpanda-labs/]
+If a lab page falls into the same categories as a doc page and the deployment types of both the doc page and the lab page match, those pages are considered related and cross-links are automatically added.
 
 === Create the documentation structure
 
-Your lab's documentation should be placed within a `docs/` directory in your project, following the Antora documentation structure. The `redpanda-labs` repository includes an initialization script in the `utility-scripts/` directory that creates this structure for you.
+Your lab's documentation should be placed within your project's `docs/` directory, following the Antora documentation structure. The `redpanda-labs` repository includes an initialization script in the `utility-scripts/` directory that creates this structure for you.
 
-To autogenerate this directory structure for your lab, execute the following script from the `utility-scripts/` directory of this repository.
+To autogenerate this directory structure for your lab, execute the following script from this repository's `utility-scripts/` directory.
 
 NOTE: This script is not supported on Windows. If you're using Windows, create the directory structure manually.
 
@@ -84,13 +75,13 @@ Replace `<lab-project-directory>` with the name of your lab directory. If this d
 ----
 
 <1> The directory of your labs project.
-<2> (Required) The `docs/` directory where all Antora content for docs is stored.
+<2> (Required) The `docs/` directory stores all Antora content for docs.
 <3> (Required) A component version descriptor file that indicates to Antora that the contents should be collected and processed.
 <4> (Required) This named module directory is where you can place all your documentation.
-<5> (Optional) The `attachments/` directory is where you can store files to be uploaded as attachments.
-<6> (Optional) The `examples/` directory is where you can store code files to be included in the documentation.
-<7> (Optional) The `images/` directory is where you can store images to be included in the documentation.
-<8> (Required) The `pages/` directory is where you store your Asciidoc documentation pages.
+<5> (Optional) The `attachments/` directory stores files to be uploaded as attachments.
+<6> (Optional) The `examples/` directory stores code files to be included in the documentation.
+<7> (Optional) The `images/` directory stores images to be included in the documentation.
+<8> (Required) The `pages/` directory stores your Asciidoc documentation pages.
 <9> (Optional) The `partials/` directory is where you can store reusable snippets of Asciidoc content to be included in the documentation.
 
 === Avoid duplication in the README
@@ -99,9 +90,9 @@ To avoid duplicating content in both the README and the Antora docs you can choo
 
 - <<symlink, *Symlink the README*>> (preferred): Ideal for keeping documentation in one location and allowing GitHub users to find docs without leaving the repository. Ensure your README uses Asciidoc markup to be compatible with Antora.
 
-- *Link to Docs in README*: Best for extensive documentation that requires single-sourcing. Simplify your README to include a link to the published docs on the Redpanda site.
+- *Link to Docs in README*: Best for extensive documentation that requires single sourcing. Simplify your README to include a link to the published docs on the Redpanda site.
 
-TIP: If you think that users will clone the repo locally and want access to docs without internet access, choose the symlinking option.
+TIP: If you think users will clone the repo locally and want access to docs without internet access, choose the symlinking option.
 
 .Pros and cons of symlinking vs providing a doc link in the README
 |===

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -5,7 +5,7 @@ asciidoc:
   attributes:
     page-header-data:
       order: 4
-      color: '#0E9384'
+      color: '#227093'
     full-version: 24.1.1
 
 

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,8 +1,11 @@
 name: redpanda-labs
-title: Redpanda Labs
+title: Labs
 version: ~
 asciidoc:
   attributes:
+    page-header-data:
+      order: 4
+      color: '#065986'
     full-version: 24.1.1
 
 

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -5,7 +5,7 @@ asciidoc:
   attributes:
     page-header-data:
       order: 4
-      color: '#065986'
+      color: '#0E9384'
     full-version: 24.1.1
 
 


### PR DESCRIPTION
Part of https://github.com/redpanda-data/documentation-private/issues/2587

- Renames the component to 'Labs' so that the UI displays it instead of 'Redpanda Labs'.
- Specifies the order that this component should be displayed in the docs header and the color of the header.