### PR TITLE
Hard-code Console version

### DIFF
--- a/docker-compose/console-plain-login/README.adoc
+++ b/docker-compose/console-plain-login/README.adoc
@@ -6,7 +6,6 @@
 // Set up attributes to hold the latest version of Redpanda and Redpanda Console.
 // For GitHub, hard-code the latest version to these values:
 ifndef::env-site[]
-:latest-console-version: 2.7.2
 :latest-redpanda-version: 24.2.7
 endif::[]
 // For the docs site, use the built-in attributes that store the latest version as fetched from GitHub releases.
@@ -65,15 +64,6 @@ For example:
 [,bash,subs="attributes+"]
 ----
 export REDPANDA_VERSION={latest-redpanda-version}
-----
-
-. Set the `REDPANDA_CONSOLE_VERSION` environment variable to the version of Redpanda Console that you want to run. For all available versions, see the https://github.com/redpanda-data/redpanda/releases[GitHub releases].
-+
-For example:
-+
-[,bash,subs="attributes+"]
-----
-export REDPANDA_CONSOLE_VERSION={latest-console-version}
 ----
 
 . Save your license key to `license/redpanda.license` in the same location as your Docker Compose file. Or, to use another location, update the license paths in the Docker Compose file to another directory that contains your license key.

--- a/docker-compose/console-plain-login/docker-compose.yml
+++ b/docker-compose/console-plain-login/docker-compose.yml
@@ -59,7 +59,7 @@ services:
       - redpanda
   console:
     container_name: redpanda-console
-    image: docker.redpanda.com/redpandadata/console:v2.8.3
+    image: docker.redpanda.com/redpandadata/console:v2.8.4
     # mount the local directory that contains your license key to the container.
     # give Redpanda Console read access to the license.
     volumes:

--- a/docker-compose/console-plain-login/docker-compose.yml
+++ b/docker-compose/console-plain-login/docker-compose.yml
@@ -59,7 +59,7 @@ services:
       - redpanda
   console:
     container_name: redpanda-console
-    image: docker.redpanda.com/redpandadata/console:v${REDPANDA_CONSOLE_VERSION:?Set a Redpanda Console version}
+    image: docker.redpanda.com/redpandadata/console:v2.8.3
     # mount the local directory that contains your license key to the container.
     # give Redpanda Console read access to the license.
     volumes:


### PR DESCRIPTION
We'll soon be releasing Console v3 which deprecates the plain login provider. This PR hard-codes the version of Console to 2.8.4 so that it continues to work.