### PR TITLE
Prefix versions with v

### DIFF
--- a/clients/stock-market-activity/nodejs/README.adoc
+++ b/clients/stock-market-activity/nodejs/README.adoc
@@ -66,7 +66,7 @@ For example:
 +
 [,bash,subs="attributes+"]
 ----
-export REDPANDA_VERSION=v{latest-redpanda-version}
+export REDPANDA_VERSION={latest-redpanda-version}
 ----
 
 . Set the `REDPANDA_CONSOLE_VERSION` environment variable to the version of Redpanda Console that you want to run. For all available versions, see the https://github.com/redpanda-data/redpanda/releases[GitHub releases].
@@ -75,7 +75,7 @@ For example:
 +
 [,bash,subs="attributes+"]
 ----
-export REDPANDA_CONSOLE_VERSION=v{latest-console-version}
+export REDPANDA_CONSOLE_VERSION={latest-console-version}
 ----
 
 . Start a local Redpanda cluster:

--- a/clients/stock-market-activity/python/README.adoc
+++ b/clients/stock-market-activity/python/README.adoc
@@ -59,7 +59,7 @@ For example:
 +
 [,bash,subs="attributes+"]
 ----
-export REDPANDA_VERSION=v{latest-redpanda-version}
+export REDPANDA_VERSION={latest-redpanda-version}
 ----
 
 . Set the `REDPANDA_CONSOLE_VERSION` environment variable to the version of Redpanda Console that you want to run. For all available versions, see the https://github.com/redpanda-data/redpanda/releases[GitHub releases].
@@ -68,7 +68,7 @@ For example:
 +
 [,bash,subs="attributes+"]
 ----
-export REDPANDA_CONSOLE_VERSION=v{latest-console-version}
+export REDPANDA_CONSOLE_VERSION={latest-console-version}
 ----
 
 . Start a local Redpanda cluster:

--- a/data-transforms/go/flatten/README.adoc
+++ b/data-transforms/go/flatten/README.adoc
@@ -84,7 +84,7 @@ For example:
 +
 [,bash,subs="attributes+"]
 ----
-export REDPANDA_VERSION=v{latest-redpanda-version}
+export REDPANDA_VERSION={latest-redpanda-version}
 ----
 
 . Set the `REDPANDA_CONSOLE_VERSION` environment variable to the version of Redpanda Console that you want to run. For all available versions, see the https://github.com/redpanda-data/redpanda/releases[GitHub releases].
@@ -95,7 +95,7 @@ For example:
 +
 [,bash,subs="attributes+"]
 ----
-export REDPANDA_CONSOLE_VERSION=v{latest-console-version}
+export REDPANDA_CONSOLE_VERSION={latest-console-version}
 ----
 
 . Start Redpanda in Docker by running the following command:

--- a/data-transforms/go/flatten/docker-compose.yml
+++ b/data-transforms/go/flatten/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   redpanda:
-    image: docker.redpanda.com/redpandadata/redpanda:${REDPANDA_VERSION:-latest}
+    image: docker.redpanda.com/redpandadata/redpanda:v${REDPANDA_VERSION:?Set a Redpanda version}
     command:
     - redpanda
     - start
@@ -19,7 +19,7 @@ services:
       - ./conf/.bootstrap.yaml:/etc/redpanda/.bootstrap.yaml
   console:
     container_name: redpanda-console
-    image: docker.redpanda.com/redpandadata/console:${REDPANDA_CONSOLE_VERSION:-latest}
+    image: docker.redpanda.com/redpandadata/console:v${REDPANDA_CONSOLE_VERSION:?Set a Redpanda Console version}
     entrypoint: /bin/sh
     command: -c 'echo "$$CONSOLE_CONFIG_FILE" > /tmp/config.yml; /app/console'
     environment:

--- a/data-transforms/go/iss_demo/README.adoc
+++ b/data-transforms/go/iss_demo/README.adoc
@@ -63,7 +63,7 @@ For example:
 +
 [,bash,subs="attributes+"]
 ----
-export REDPANDA_VERSION=v{latest-redpanda-version}
+export REDPANDA_VERSION={latest-redpanda-version}
 ----
 
 . Set the `REDPANDA_CONSOLE_VERSION` environment variable to the version of Redpanda Console that you want to run. For all available versions, see the https://github.com/redpanda-data/redpanda/releases[GitHub releases].
@@ -74,7 +74,7 @@ For example:
 +
 [,bash,subs="attributes+"]
 ----
-export REDPANDA_CONSOLE_VERSION=v{latest-console-version}
+export REDPANDA_CONSOLE_VERSION={latest-console-version}
 ----
 
 . Start Redpanda in Docker by running the following command:

--- a/data-transforms/go/iss_demo/docker-compose.yml
+++ b/data-transforms/go/iss_demo/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   redpanda:
-    image: docker.redpanda.com/redpandadata/redpanda:${REDPANDA_VERSION:-latest}
+    image: docker.redpanda.com/redpandadata/redpanda:v${REDPANDA_VERSION:?Set a Redpanda version}
     command:
     - redpanda
     - start
@@ -19,7 +19,7 @@ services:
       - ./conf/.bootstrap.yaml:/etc/redpanda/.bootstrap.yaml
   console:
     container_name: redpanda-console
-    image: docker.redpanda.com/redpandadata/console:${REDPANDA_CONSOLE_VERSION:-latest}
+    image: docker.redpanda.com/redpandadata/console:v${REDPANDA_CONSOLE_VERSION:?Set a Redpanda Console version}
     entrypoint: /bin/sh
     command: -c 'echo "$$CONSOLE_CONFIG_FILE" > /tmp/config.yml; /app/console'
     environment:

--- a/data-transforms/go/redaction/demo/.env
+++ b/data-transforms/go/redaction/demo/.env
@@ -1,1 +1,1 @@
-IMAGE=redpandadata/redpanda:${REDPANDA_VERSION:-latest}
+IMAGE=redpandadata/redpanda:v${REDPANDA_VERSION:?Set a Redpanda version}

--- a/data-transforms/go/redaction/demo/README.adoc
+++ b/data-transforms/go/redaction/demo/README.adoc
@@ -57,7 +57,7 @@ For example:
 +
 [,bash,subs="attributes+"]
 ----
-export REDPANDA_VERSION=v{latest-redpanda-version}
+export REDPANDA_VERSION={latest-redpanda-version}
 ----
 
 
@@ -69,7 +69,7 @@ For example:
 +
 [,bash,subs="attributes+"]
 ----
-export REDPANDA_CONSOLE_VERSION=v{latest-console-version}
+export REDPANDA_CONSOLE_VERSION={latest-console-version}
 ----
 
 . Build the data transforms container:

--- a/data-transforms/go/redaction/demo/docker-compose.yml
+++ b/data-transforms/go/redaction/demo/docker-compose.yml
@@ -34,7 +34,7 @@ services:
     volumes:
       - ./conf/.bootstrap.yaml:/etc/redpanda/.bootstrap.yaml
   console:
-    image: docker.redpanda.com/redpandadata/console:${REDPANDA_CONSOLE_VERSION:-latest}
+    image: docker.redpanda.com/redpandadata/console:v${REDPANDA_CONSOLE_VERSION:?Set a Redpanda Console version}
     restart: on-failure
     entrypoint: /bin/sh
     command: -c "echo \"$$CONSOLE_CONFIG_FILE\" > /tmp/config.yml; /app/console"

--- a/data-transforms/go/regex/README.adoc
+++ b/data-transforms/go/regex/README.adoc
@@ -56,7 +56,7 @@ For example:
 +
 [,bash,subs="attributes+"]
 ----
-export REDPANDA_VERSION=v{latest-redpanda-version}
+export REDPANDA_VERSION={latest-redpanda-version}
 ----
 
 . Set the `REDPANDA_CONSOLE_VERSION` environment variable to the version of Redpanda Console that you want to run. For all available versions, see the https://github.com/redpanda-data/redpanda/releases[GitHub releases].
@@ -67,7 +67,7 @@ For example:
 +
 [,bash,subs="attributes+"]
 ----
-export REDPANDA_CONSOLE_VERSION=v{latest-console-version}
+export REDPANDA_CONSOLE_VERSION={latest-console-version}
 ----
 
 . Start Redpanda in Docker by running the following command:

--- a/data-transforms/go/regex/docker-compose.yml
+++ b/data-transforms/go/regex/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   redpanda:
-    image: docker.redpanda.com/redpandadata/redpanda:${REDPANDA_VERSION:-latest}
+    image: docker.redpanda.com/redpandadata/redpanda:v${REDPANDA_VERSION:?Set a Redpanda version}
     command:
     - redpanda
     - start
@@ -19,7 +19,7 @@ services:
       - ./conf/.bootstrap.yaml:/etc/redpanda/.bootstrap.yaml
   console:
     container_name: redpanda-console
-    image: docker.redpanda.com/redpandadata/console:${REDPANDA_CONSOLE_VERSION:-latest}
+    image: docker.redpanda.com/redpandadata/console:v${REDPANDA_CONSOLE_VERSION:?Set a Redpanda Console version}
     entrypoint: /bin/sh
     command: -c 'echo "$$CONSOLE_CONFIG_FILE" > /tmp/config.yml; /app/console'
     environment:

--- a/data-transforms/go/to_avro/README.adoc
+++ b/data-transforms/go/to_avro/README.adoc
@@ -47,7 +47,7 @@ For example:
 +
 [,bash,subs="attributes+"]
 ----
-export REDPANDA_VERSION=v{latest-redpanda-version}
+export REDPANDA_VERSION={latest-redpanda-version}
 ----
 
 . Set the `REDPANDA_CONSOLE_VERSION` environment variable to the version of Redpanda Console that you want to run. For all available versions, see the https://github.com/redpanda-data/redpanda/releases[GitHub releases].
@@ -58,7 +58,7 @@ For example:
 +
 [,bash,subs="attributes+"]
 ----
-export REDPANDA_CONSOLE_VERSION=v{latest-console-version}
+export REDPANDA_CONSOLE_VERSION={latest-console-version}
 ----
 
 . Start Redpanda in Docker by running the following command:

--- a/data-transforms/go/to_avro/docker-compose.yml
+++ b/data-transforms/go/to_avro/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   redpanda:
     container_name: redpanda
-    image: docker.redpanda.com/redpandadata/redpanda:${REDPANDA_VERSION:-latest}
+    image: docker.redpanda.com/redpandadata/redpanda:v${REDPANDA_VERSION:?Set a Redpanda version}
     command:
     - redpanda
     - start
@@ -20,7 +20,7 @@ services:
       - ./conf/.bootstrap.yaml:/etc/redpanda/.bootstrap.yaml
   console:
     container_name: redpanda-console
-    image: docker.redpanda.com/redpandadata/console:${REDPANDA_CONSOLE_VERSION:-latest}
+    image: docker.redpanda.com/redpandadata/console:v${REDPANDA_CONSOLE_VERSION:?Set a Redpanda Console version}
     entrypoint: /bin/sh
     command: -c 'echo "$$CONSOLE_CONFIG_FILE" > /tmp/config.yml; /app/console'
     environment:

--- a/data-transforms/js/csv-json/docker-compose.yml
+++ b/data-transforms/js/csv-json/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   redpanda:
-    image: docker.redpanda.com/redpandadata/redpanda:${REDPANDA_VERSION:-latest}
+    image: docker.redpanda.com/redpandadata/redpanda:v${REDPANDA_VERSION:?Set a Redpanda version}
     command:
     - redpanda
     - start
@@ -19,7 +19,7 @@ services:
       - ./conf/.bootstrap.yaml:/etc/redpanda/.bootstrap.yaml
   console:
     container_name: redpanda-console
-    image: docker.redpanda.com/redpandadata/console:${REDPANDA_CONSOLE_VERSION:-latest}
+    image: docker.redpanda.com/redpandadata/console:v${REDPANDA_CONSOLE_VERSION:?Set a Redpanda Console version}
     entrypoint: /bin/sh
     command: -c 'echo "$$CONSOLE_CONFIG_FILE" > /tmp/config.yml; /app/console'
     environment:

--- a/data-transforms/rust/jq/README.adoc
+++ b/data-transforms/rust/jq/README.adoc
@@ -59,7 +59,7 @@ For example:
 +
 [,bash,subs="attributes+"]
 ----
-export REDPANDA_VERSION=v{latest-redpanda-version}
+export REDPANDA_VERSION={latest-redpanda-version}
 ----
 
 . Set the `REDPANDA_CONSOLE_VERSION` environment variable to the version of Redpanda Console that you want to run. For all available versions, see the https://github.com/redpanda-data/redpanda/releases[GitHub releases].
@@ -70,7 +70,7 @@ For example:
 +
 [,bash,subs="attributes+"]
 ----
-export REDPANDA_CONSOLE_VERSION=v{latest-console-version}
+export REDPANDA_CONSOLE_VERSION={latest-console-version}
 ----
 
 . Start Redpanda in Docker by running the following command:

--- a/data-transforms/rust/jq/docker-compose.yml
+++ b/data-transforms/rust/jq/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   redpanda:
-    image: docker.redpanda.com/redpandadata/redpanda:${REDPANDA_VERSION:-latest}
+    image: docker.redpanda.com/redpandadata/redpanda:v${REDPANDA_VERSION:?Set a Redpanda version}
     command:
     - redpanda
     - start
@@ -19,7 +19,7 @@ services:
       - ./conf/.bootstrap.yaml:/etc/redpanda/.bootstrap.yaml
   console:
     container_name: redpanda-console
-    image: docker.redpanda.com/redpandadata/console:${REDPANDA_CONSOLE_VERSION:-latest}
+    image: docker.redpanda.com/redpandadata/console:v${REDPANDA_CONSOLE_VERSION:?Set a Redpanda Console version}
     entrypoint: /bin/sh
     command: -c 'echo "$$CONSOLE_CONFIG_FILE" > /tmp/config.yml; /app/console'
     environment:

--- a/data-transforms/rust/ts-converter/README.adoc
+++ b/data-transforms/rust/ts-converter/README.adoc
@@ -57,7 +57,7 @@ For example:
 +
 [,bash,subs="attributes+"]
 ----
-export REDPANDA_VERSION=v{latest-redpanda-version}
+export REDPANDA_VERSION={latest-redpanda-version}
 ----
 
 . Set the `REDPANDA_CONSOLE_VERSION` environment variable to the version of Redpanda Console that you want to run. For all available versions, see the https://github.com/redpanda-data/redpanda/releases[GitHub releases^].
@@ -66,7 +66,7 @@ For example:
 +
 [,bash,subs="attributes+"]
 ----
-export REDPANDA_CONSOLE_VERSION=v{latest-console-version}
+export REDPANDA_CONSOLE_VERSION={latest-console-version}
 ----
 
 . Start Redpanda in Docker by running the following command:

--- a/data-transforms/rust/ts-converter/docker-compose.yml
+++ b/data-transforms/rust/ts-converter/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   redpanda:
-    image: docker.redpanda.com/redpandadata/redpanda:${REDPANDA_VERSION:-latest}
+    image: docker.redpanda.com/redpandadata/redpanda:v${REDPANDA_VERSION:?Set a Redpanda version}
     command:
     - redpanda
     - start
@@ -19,7 +19,7 @@ services:
       - ./conf/.bootstrap.yaml:/etc/redpanda/.bootstrap.yaml
   console:
     container_name: redpanda-console
-    image: docker.redpanda.com/redpandadata/console:${REDPANDA_CONSOLE_VERSION:-latest}
+    image: docker.redpanda.com/redpandadata/console:v${REDPANDA_CONSOLE_VERSION:?Set a Redpanda Console version}
     entrypoint: /bin/sh
     command: -c 'echo "$$CONSOLE_CONFIG_FILE" > /tmp/config.yml; /app/console'
     environment:

--- a/docker-compose/cdc/mysql-json/README.adoc
+++ b/docker-compose/cdc/mysql-json/README.adoc
@@ -55,7 +55,7 @@ For example:
 +
 [,bash,subs="attributes+"]
 ----
-export REDPANDA_VERSION=v{latest-redpanda-version}
+export REDPANDA_VERSION={latest-redpanda-version}
 ----
 
 . Run the following in the directory where you saved the Docker Compose file:
@@ -157,7 +157,7 @@ docker compose exec redpanda rpk topic consume dbz.pandashop.orders
 +
 [,bash,subs="attributes+"]
 ----
-export REDPANDA_VERSION=v{latest-redpanda-version}
+export REDPANDA_VERSION={latest-redpanda-version}
 docker compose exec mysql mysql -u mysqluser -p
 ----
 +

--- a/docker-compose/cdc/mysql-json/docker-compose.yml
+++ b/docker-compose/cdc/mysql-json/docker-compose.yml
@@ -16,7 +16,7 @@ services:
         - ./data/mysql.cnf:/etc/mysql/conf.d
         - ./data/mysql_bootstrap.sql:/docker-entrypoint-initdb.d/mysql_bootstrap.sql
   redpanda:
-    image: docker.redpanda.com/redpandadata/redpanda:${REDPANDA_VERSION:-latest}
+    image: docker.redpanda.com/redpandadata/redpanda:v${REDPANDA_VERSION:?Set a Redpanda version}
     container_name: redpanda
     command:
       - redpanda start

--- a/docker-compose/cdc/postgres-json/README.adoc
+++ b/docker-compose/cdc/postgres-json/README.adoc
@@ -55,7 +55,7 @@ For example:
 +
 [,bash,subs="attributes+"]
 ----
-export REDPANDA_VERSION=v{latest-redpanda-version}
+export REDPANDA_VERSION={latest-redpanda-version}
 ----
 
 . Run the following in the directory where you saved the Docker Compose file:
@@ -130,7 +130,7 @@ docker compose exec redpanda rpk topic consume dbz.public.orders
 +
 [,bash,subs="attributes+"]
 ----
-export REDPANDA_VERSION=v{latest-redpanda-version}
+export REDPANDA_VERSION={latest-redpanda-version}
 docker compose exec postgres psql -U postgresuser -d pandashop
 ----
 

--- a/docker-compose/cdc/postgres-json/docker-compose.yml
+++ b/docker-compose/cdc/postgres-json/docker-compose.yml
@@ -20,7 +20,7 @@ services:
     volumes:
       - ./data:/docker-entrypoint-initdb.d
   redpanda:
-    image: docker.redpanda.com/redpandadata/redpanda:${REDPANDA_VERSION:-latest}
+    image: docker.redpanda.com/redpandadata/redpanda:v${REDPANDA_VERSION:?Set a Redpanda version}
     container_name: redpanda
     command:
       - redpanda start

--- a/docker-compose/console-plain-login/README.adoc
+++ b/docker-compose/console-plain-login/README.adoc
@@ -63,7 +63,7 @@ For example:
 +
 [,bash,subs="attributes+"]
 ----
-export REDPANDA_VERSION=v{latest-redpanda-version}
+export REDPANDA_VERSION={latest-redpanda-version}
 ----
 
 . Save your license key to `license/redpanda.license` in the same location as your Docker Compose file. Or, to use another location, update the license paths in the Docker Compose file to another directory that contains your license key.

--- a/docker-compose/console-plain-login/docker-compose.yml
+++ b/docker-compose/console-plain-login/docker-compose.yml
@@ -7,7 +7,7 @@ volumes:
   redpanda: null
 services:
   redpanda:
-    image: docker.redpanda.com/redpandadata/redpanda:${REDPANDA_VERSION:-latest}
+    image: docker.redpanda.com/redpandadata/redpanda:v${REDPANDA_VERSION:?Set a Redpanda version}
     command:
       - redpanda start
       # Mode dev-container uses well-known configuration properties for development in containers.
@@ -48,7 +48,7 @@ services:
       - /etc/redpanda/redpanda.license
       # rpk connects to the admin API of one broker to set the license key for the whole cluster.
       - -X admin.hosts=redpanda:9644
-    image: docker.redpanda.com/redpandadata/redpanda:${REDPANDA_VERSION:-latest}
+    image: docker.redpanda.com/redpandadata/redpanda:v${REDPANDA_VERSION:?Set a Redpanda version}
     # mount the local directory that contains your license key to the container.
     # give Redpanda read and write access to the license.
     volumes:

--- a/docker-compose/data-transforms/docker-compose.yml
+++ b/docker-compose/data-transforms/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   redpanda:
-    image: docker.redpanda.com/redpandadata/redpanda:${REDPANDA_VERSION:-latest}
+    image: docker.redpanda.com/redpandadata/redpanda:v${REDPANDA_VERSION:?Set a Redpanda version}
     command:
     - redpanda
     - start
@@ -19,7 +19,7 @@ services:
       - ./conf/.bootstrap.yaml:/etc/redpanda/.bootstrap.yaml
   console:
     container_name: redpanda-console
-    image: docker.redpanda.com/redpandadata/console:${REDPANDA_CONSOLE_VERSION:-latest}
+    image: docker.redpanda.com/redpandadata/console:v${REDPANDA_CONSOLE_VERSION:?Set a Redpanda Console version}
     entrypoint: /bin/sh
     command: -c 'echo "$$CONSOLE_CONFIG_FILE" > /tmp/config.yml; /app/console'
     environment:

--- a/docker-compose/iceberg/README.adoc
+++ b/docker-compose/iceberg/README.adoc
@@ -72,7 +72,7 @@ For example:
 +
 [,bash,subs="attributes+"]
 ----
-export REDPANDA_VERSION=v{latest-redpanda-version}
+export REDPANDA_VERSION={latest-redpanda-version}
 ----
 
 . Set the `REDPANDA_CONSOLE_VERSION` environment variable to the version of Redpanda Console that you want to run. For all available versions, see the https://github.com/redpanda-data/redpanda/releases[GitHub releases].
@@ -83,7 +83,7 @@ For example:
 +
 [,bash,subs="attributes+"]
 ----
-export REDPANDA_CONSOLE_VERSION=v{latest-console-version}
+export REDPANDA_CONSOLE_VERSION={latest-console-version}
 ----
 
 . Start the Docker Compose environment, which includes Redpanda, MinIO, Spark, and Jupyter Notebook:

--- a/docker-compose/owl-shop/README.adoc
+++ b/docker-compose/owl-shop/README.adoc
@@ -61,7 +61,7 @@ For example:
 +
 [,bash,subs="attributes+"]
 ----
-export REDPANDA_VERSION=v{latest-redpanda-version}
+export REDPANDA_VERSION={latest-redpanda-version}
 ----
 
 . Set the `REDPANDA_CONSOLE_VERSION` environment variable to the version of Redpanda Console that you want to run. For all available versions, see the https://github.com/redpanda-data/redpanda/releases[GitHub releases].
@@ -72,7 +72,7 @@ For example:
 +
 [,bash,subs="attributes+"]
 ----
-export REDPANDA_CONSOLE_VERSION=v{latest-console-version}
+export REDPANDA_CONSOLE_VERSION={latest-console-version}
 ----
 
 . Run the following in the directory where you saved the Docker Compose file:

--- a/docker-compose/owl-shop/docker-compose.yml
+++ b/docker-compose/owl-shop/docker-compose.yml
@@ -6,7 +6,7 @@ volumes:
   redpanda: null
 services:
   redpanda:
-    image: docker.redpanda.com/redpandadata/redpanda:${REDPANDA_VERSION:-latest}
+    image: docker.redpanda.com/redpandadata/redpanda:v${REDPANDA_VERSION:?Set a Redpanda version}
     command:
       - redpanda start
       - --kafka-addr internal://0.0.0.0:9092,external://0.0.0.0:19092
@@ -43,7 +43,7 @@ services:
       retries: 5
       start_period: 5s
   console:
-    image: docker.redpanda.com/redpandadata/console:${REDPANDA_CONSOLE_VERSION:-latest}
+    image: docker.redpanda.com/redpandadata/console:v${REDPANDA_CONSOLE_VERSION:?Set a Redpanda Console version}
     entrypoint: /bin/sh
     command: -c "echo \"$$CONSOLE_CONFIG_FILE\" > /tmp/config.yml; /app/console"
     environment:

--- a/docker-compose/single-broker/README.adoc
+++ b/docker-compose/single-broker/README.adoc
@@ -61,7 +61,7 @@ For example:
 +
 [,bash,subs="attributes+"]
 ----
-export REDPANDA_VERSION=v{latest-redpanda-version}
+export REDPANDA_VERSION={latest-redpanda-version}
 ----
 
 . Set the `REDPANDA_CONSOLE_VERSION` environment variable to the version of Redpanda Console that you want to run. For all available versions, see the https://github.com/redpanda-data/redpanda/releases[GitHub releases].
@@ -70,7 +70,7 @@ For example:
 +
 [,bash,subs="attributes+"]
 ----
-export REDPANDA_CONSOLE_VERSION=v{latest-console-version}
+export REDPANDA_CONSOLE_VERSION={latest-console-version}
 ----
 
 . Run the following in the directory where you saved the Docker Compose file:

--- a/docker-compose/single-broker/docker-compose.yml
+++ b/docker-compose/single-broker/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       # Tells Seastar (the framework Redpanda uses under the hood) to use 1 core on the system.
       - --smp 1
       - --default-log-level=info
-    image: docker.redpanda.com/redpandadata/redpanda:${REDPANDA_VERSION:-latest}
+    image: docker.redpanda.com/redpandadata/redpanda:v${REDPANDA_VERSION:?Set a Redpanda version}
     container_name: redpanda-0
     volumes:
       - redpanda-0:/var/lib/redpanda/data
@@ -41,7 +41,7 @@ services:
       - 19644:9644
   console:
     container_name: redpanda-console
-    image: docker.redpanda.com/redpandadata/console:${REDPANDA_CONSOLE_VERSION:-latest}
+    image: docker.redpanda.com/redpandadata/console:v${REDPANDA_CONSOLE_VERSION:?Set a Redpanda Console version}
     networks:
       - redpanda_network
     entrypoint: /bin/sh

--- a/docker-compose/three-brokers/README.adoc
+++ b/docker-compose/three-brokers/README.adoc
@@ -61,7 +61,7 @@ For example:
 +
 [,bash,subs="attributes+"]
 ----
-export REDPANDA_VERSION=v{latest-redpanda-version}
+export REDPANDA_VERSION={latest-redpanda-version}
 ----
 
 . Set the `REDPANDA_CONSOLE_VERSION` environment variable to the version of Redpanda Console that you want to run. For all available versions, see the https://github.com/redpanda-data/redpanda/releases[GitHub releases].
@@ -72,7 +72,7 @@ For example:
 +
 [,bash,subs="attributes+"]
 ----
-export REDPANDA_CONSOLE_VERSION=v{latest-console-version}
+export REDPANDA_CONSOLE_VERSION={latest-console-version}
 ----
 
 . Run the following in the directory where you saved the Docker Compose file:

--- a/docker-compose/three-brokers/docker-compose.yml
+++ b/docker-compose/three-brokers/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       # Tells Seastar (the framework Redpanda uses under the hood) to use 1 core on the system.
       - --smp 1
       - --default-log-level=info
-    image: docker.redpanda.com/redpandadata/redpanda:${REDPANDA_VERSION:-latest}
+    image: docker.redpanda.com/redpandadata/redpanda:v${REDPANDA_VERSION:?Set a Redpanda version}
     container_name: redpanda-0
     volumes:
       - redpanda-0:/var/lib/redpanda/data
@@ -55,7 +55,7 @@ services:
       - --smp 1
       - --default-log-level=info
       - --seeds redpanda-0:33145
-    image: docker.redpanda.com/redpandadata/redpanda:${REDPANDA_VERSION:-latest}
+    image: docker.redpanda.com/redpandadata/redpanda:v${REDPANDA_VERSION:?Set a Redpanda version}
     container_name: redpanda-1
     volumes:
       - redpanda-1:/var/lib/redpanda/data
@@ -83,7 +83,7 @@ services:
       - --smp 1
       - --default-log-level=info
       - --seeds redpanda-0:33145
-    image: docker.redpanda.com/redpandadata/redpanda:${REDPANDA_VERSION:-latest}
+    image: docker.redpanda.com/redpandadata/redpanda:v${REDPANDA_VERSION:?Set a Redpanda version}
     container_name: redpanda-2
     volumes:
       - redpanda-2:/var/lib/redpanda/data
@@ -98,7 +98,7 @@ services:
       - redpanda-0
   console:
     container_name: redpanda-console
-    image: docker.redpanda.com/redpandadata/console:${REDPANDA_CONSOLE_VERSION:-latest}
+    image: docker.redpanda.com/redpandadata/console:v${REDPANDA_CONSOLE_VERSION:?Set a Redpanda Console version}
     networks:
       - redpanda_network
     entrypoint: /bin/sh


### PR DESCRIPTION
The automation that replaces environment variables with versions during a docs build does not include the `v` prefix. As a result, we need to make sure the Docker Compose files include that prefix.