### PR TITLE
always build spark image in iceberg compose

### DIFF
--- a/docker-compose/iceberg/docker-compose.yml
+++ b/docker-compose/iceberg/docker-compose.yml
@@ -142,7 +142,6 @@ services:
       - CATALOG_IO__IMPL=org.apache.iceberg.aws.s3.S3FileIO
       - CATALOG_S3_ENDPOINT=http://minio:9000
   spark-iceberg:
-    image: tabulario/spark-iceberg
     container_name: spark-iceberg
     build: spark/
     networks:


### PR DESCRIPTION
We need the customized version of spark rather than default image from docker hub. To avoid users accidentally starting with the wrong image if they didn't run docker build prior to running compose we are removing the image reference altogether so that we always execute the build.