### PR TITLE
chore: wire conditional-home-redirect and unified-navigation extensions

### DIFF
--- a/docs/local-antora-playbook.yml
+++ b/docs/local-antora-playbook.yml
@@ -66,7 +66,7 @@ antora:
   - require: '@redpanda-data/docs-extensions-and-macros/extensions/archive-attachments'
     data:
       archives:
-        - component: 'ROOT'
+        - component: 'streaming'
           output_archive: 'redpanda-quickstart.tar.gz'
           file_patterns:
             - '**/test-resources/**/docker-compose/**'
@@ -74,7 +74,7 @@ antora:
     data:
       replacements:
         - components:
-            - 'ROOT'
+            - 'streaming'
             - 'labs'
           file_patterns:
             - '**/docker-compose.yaml'

--- a/docs/local-antora-playbook.yml
+++ b/docs/local-antora-playbook.yml
@@ -21,7 +21,7 @@ content:
     branches: [main]
   - url: https://github.com/redpanda-data/docs-site
     branches: 'main'
-    start_paths: [home]
+    start_paths: [home, data-platform, self-managed]
   - url: https://github.com/redpanda-data/cloud-docs
     branches: [main]
   # https://docs.antora.org/antora/latest/playbook/content-source-url/#local-urls
@@ -43,6 +43,12 @@ asciidoc:
   - '@redpanda-data/docs-extensions-and-macros/asciidoc-extensions/add-line-numbers-highlights'
 antora:
   extensions:
+  # Conditional home page redirect when agentic-data-plane component doesn't exist
+  - require: '@redpanda-data/docs-extensions-and-macros/extensions/conditional-home-redirect'
+  # Unified navigation extension (config-driven)
+  # Components with page-navigation attribute use that config
+  # Components without page-navigation use standard Antora navigation
+  - require: '@redpanda-data/docs-extensions-and-macros/extensions/unified-navigation'
   - require: '@redpanda-data/docs-extensions-and-macros/extensions/generate-rp-connect-info'
   - require: '@redpanda-data/docs-extensions-and-macros/extensions/unpublish-pages'
   - require: '@redpanda-data/docs-extensions-and-macros/extensions/add-global-attributes'


### PR DESCRIPTION
This pull request updates the Antora playbook to improve documentation structure and navigation by including additional content sources and enabling new Antora extensions.

**Content source updates:**

* Added `data-platform` and `self-managed` to the `start_paths` for the `docs-site` content source, allowing these documentation sections to be included in local builds.

**Antora extension enhancements:**

* Enabled the `conditional-home-redirect` extension to support conditional homepage redirects based on the presence of the `agentic-data-plane` component.
* Enabled the `unified-navigation` extension, which provides a config-driven unified navigation experience for components with the `page-navigation` attribute.