### PR TITLE
DOC-2303: Fix stale docs repo URL in local playbook + Antora auth setup docs

### DIFF
--- a/docs/CONTRIBUTING.adoc
+++ b/docs/CONTRIBUTING.adoc
@@ -189,7 +189,7 @@ If this command fails, you don't have Node.js installed.
 
 . Set up GitHub authentication for Antora.
 +
-The local Antora playbook fetches content from the private `docs`, `cloud-docs`, and `rp-connect-docs` repositories, so building the site requires a GitHub token. Antora does not use git credential helpers (such as the `gh` CLI helper or the macOS keychain), so you must complete this step even if `git clone` already works on your machine. By default, Antora reads credentials from the `GIT_CREDENTIALS` environment variable or the `~/.git-credentials` file (with a fallback to `$XDG_CONFIG_HOME/git/credentials`). To store credentials one time using the https://cli.github.com[GitHub CLI^], run:
+The local Antora playbook fetches content from the private `docs`, `cloud-docs`, and `rp-connect-docs` repositories, so building the site requires a GitHub token. Antora does not use git credential helpers (such as the `gh` CLI helper or the macOS keychain), so you must complete this step even if `git clone` already works on your machine. By default, Antora reads credentials from the `GIT_CREDENTIALS` environment variable or the `~/.git-credentials` file (with a fallback to `$XDG_CONFIG_HOME/git/credentials`). If you aren't already signed in to the https://cli.github.com[GitHub CLI^], run `gh auth login` first. Then store credentials one time:
 +
 [,bash]
 ----
@@ -197,7 +197,7 @@ echo "https://$(gh auth token):@github.com" >> ~/.git-credentials
 chmod 600 ~/.git-credentials
 ----
 +
-If you don't use the GitHub CLI, https://github.com/settings/personal-access-tokens/new[create a fine-grained personal access token^] with `Contents: Read-only` permission on the `redpanda-data` doc repositories and use it in place of `$(gh auth token)`.
+If you don't use the GitHub CLI, https://github.com/settings/personal-access-tokens/new[create a fine-grained personal access token^]: select `redpanda-data` as the resource owner, grant the token access to the private doc repositories, and set the `Contents` permission to read-only. Use the token in place of `$(gh auth token)`. Organization approval may be required before the token becomes active.
 
 . Install dependencies.
 +

--- a/docs/CONTRIBUTING.adoc
+++ b/docs/CONTRIBUTING.adoc
@@ -189,7 +189,7 @@ If this command fails, you don't have Node.js installed.
 
 . Set up GitHub authentication for Antora.
 +
-The local Antora playbook fetches content from private GitHub repositories (`docs` and `cloud-docs`), so building the site requires a GitHub token. Antora does not use git credential helpers (such as the `gh` CLI helper or the macOS keychain), even if `git clone` already works on your machine. It reads credentials only from the `GIT_CREDENTIALS` environment variable or the `~/.git-credentials` file. One-time setup using the https://cli.github.com[GitHub CLI]:
+The local Antora playbook fetches content from the private `docs`, `cloud-docs`, and `rp-connect-docs` repositories, so building the site requires a GitHub token. Antora does not use git credential helpers (such as the `gh` CLI helper or the macOS keychain), so you must complete this step even if `git clone` already works on your machine. By default, Antora reads credentials from the `GIT_CREDENTIALS` environment variable or the `~/.git-credentials` file (with a fallback to `$XDG_CONFIG_HOME/git/credentials`). To store credentials one time using the https://cli.github.com[GitHub CLI^], run:
 +
 [,bash]
 ----
@@ -197,7 +197,7 @@ echo "https://$(gh auth token):@github.com" >> ~/.git-credentials
 chmod 600 ~/.git-credentials
 ----
 +
-If you don't use the GitHub CLI, https://github.com/settings/personal-access-tokens/new[create a fine-grained personal access token] with `Contents: Read-only` permission on the `redpanda-data` doc repositories and use it in place of `$(gh auth token)`.
+If you don't use the GitHub CLI, https://github.com/settings/personal-access-tokens/new[create a fine-grained personal access token^] with `Contents: Read-only` permission on the `redpanda-data` doc repositories and use it in place of `$(gh auth token)`.
 
 . Install dependencies.
 +

--- a/docs/CONTRIBUTING.adoc
+++ b/docs/CONTRIBUTING.adoc
@@ -187,6 +187,18 @@ node --version
 +
 If this command fails, you don't have Node.js installed.
 
+. Set up GitHub authentication for Antora.
++
+The local Antora playbook fetches content from private GitHub repositories (`docs` and `cloud-docs`), so building the site requires a GitHub token. Antora does not use git credential helpers (such as the `gh` CLI helper or the macOS keychain), even if `git clone` already works on your machine. It reads credentials only from the `GIT_CREDENTIALS` environment variable or the `~/.git-credentials` file. One-time setup using the https://cli.github.com[GitHub CLI]:
++
+[,bash]
+----
+echo "https://$(gh auth token):@github.com" >> ~/.git-credentials
+chmod 600 ~/.git-credentials
+----
++
+If you don't use the GitHub CLI, https://github.com/settings/personal-access-tokens/new[create a fine-grained personal access token] with `Contents: Read-only` permission on the `redpanda-data` doc repositories and use it in place of `$(gh auth token)`.
+
 . Install dependencies.
 +
 [,bash]

--- a/docs/local-antora-playbook.yml
+++ b/docs/local-antora-playbook.yml
@@ -21,7 +21,7 @@ content:
     branches: [main]
   - url: https://github.com/redpanda-data/docs-site
     branches: 'main'
-    start_paths: [home]
+    start_paths: [home, data-platform, self-managed]
   - url: https://github.com/redpanda-data/cloud-docs
     branches: [main]
   # https://docs.antora.org/antora/latest/playbook/content-source-url/#local-urls

--- a/docs/local-antora-playbook.yml
+++ b/docs/local-antora-playbook.yml
@@ -15,8 +15,8 @@ runtime:
     failure_level: error
 content:
   sources:
-  - url: https://github.com/redpanda-data/documentation
-    branches: [main, v/*, api, site-search, shared]
+  - url: https://github.com/redpanda-data/docs
+    branches: [main, v/*, site-search, shared]
   - url: https://github.com/redpanda-data/rp-connect-docs
     branches: [main]
   - url: https://github.com/redpanda-data/docs-site


### PR DESCRIPTION
## Description

Resolves https://redpandadata.atlassian.net/browse/DOC-2303
Review deadline: 2026-08-11

The doc content repos (`docs`, `cloud-docs`, `rp-connect-docs`, `adp-docs`) are being made private. Antora fetches these repos as remote content sources during every local build, and it does not use git credential helpers, so writers need a one-time credentials setup that isn't covered by an existing `gh` or keychain login.

This PR fixes the stale `redpanda-data/documentation` content source in `docs/local-antora-playbook.yml` (now `redpanda-data/docs`, dropping the nonexistent `api` branch) and adds a one-time GitHub authentication step to the local build instructions in `docs/CONTRIBUTING.adoc`.

Merge alongside the repo visibility change (tracked in DEVPROD-4604).

## Page previews

None: Contributing-guide and local playbook changes only, no site pages affected.

## Checks

- [x] Small fix (typos, links, copyedits, etc)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
