### PR TITLE
Drop dead style guide link (DOC-2303)

### DIFF
--- a/docs/CONTRIBUTING.adoc
+++ b/docs/CONTRIBUTING.adoc
@@ -216,8 +216,6 @@ The web server's host URL is printed to the console.
 
 == Documentation guidelines
 
-For rules and recommendations as well as help with Asciidoc syntax, see the link:https://github.com/redpanda-data/docs-site/blob/main/meta-docs/STYLE-GUIDE.adoc[Redpanda docs style guide].
-
 In general:
 
 * Keep your language simple and accessible.


### PR DESCRIPTION
## Description

Related to https://redpandadata.atlassian.net/browse/DOC-2303.

`docs-site/meta-docs/STYLE-GUIDE.adoc` has been deleted (redpanda-data/docs-site#201) — the canonical style guide now lives in the private `redpanda-data/docs-team-standards` repo. Unlike `docs`/`cloud-docs`/`rp-connect-docs`/`adp-docs`/`docs-template`, this repo stays public with real external contributors, so it can't link to a private repo the way those now do. This drops the dangling reference; the inline guidelines right below it (simple language, code blocks/screenshots, logical headings) still stand on their own without it.