### PR TITLE
DOC-2303: Opt in to the contribution CTA via page-contribution attribute

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -8,7 +8,7 @@ asciidoc:
       description: "Hands-on tutorials and example applications."
       color: "#227093"
       icon: "flask"
-    page-contribution: true
+    page-contribution: 'true'
     full-version: 24.2.2
 
 

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -8,6 +8,7 @@ asciidoc:
       description: "Hands-on tutorials and example applications."
       color: "#227093"
       icon: "flask"
+    page-contribution: true
     full-version: 24.2.2
 
 


### PR DESCRIPTION
Part of [DOC-2303](https://redpandadata.atlassian.net/browse/DOC-2303).

The docs-ui contribution UI (Make a contribution CTA + contributors modal) is switching from private-origin detection to explicit opt-in via the `page-contribution` attribute (docs-ui PR to follow). redpanda-labs remains public and welcomes community contributions, so this sets the attribute at the component level to keep the CTA on all labs pages.

No effect until the docs-ui change ships; harmless to merge in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOC-2303]: https://redpandadata.atlassian.net/browse/DOC-2303?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ