### PR TITLE
chore: consume the shared component from the shared/ folder on main

### DIFF
--- a/docs/local-antora-playbook.yml
+++ b/docs/local-antora-playbook.yml
@@ -16,7 +16,10 @@ runtime:
 content:
   sources:
   - url: https://github.com/redpanda-data/docs
-    branches: [main, v/*, site-search, shared]
+    branches: [main, v/*, site-search]
+  - url: https://github.com/redpanda-data/docs
+    branches: main
+    start_path: shared
   - url: https://github.com/redpanda-data/rp-connect-docs
     branches: [main]
   - url: https://github.com/redpanda-data/docs-site


### PR DESCRIPTION
## What this does

Points this playbook at the shared component's new home. The component is moving from the dedicated `shared` branch of `redpanda-data/docs` to a `shared/` folder on `main`, so this:

- drops `shared` from the `branches` list of the `redpanda-data/docs` source
- adds the folder as its own content source with `start_path: shared`

Same shape as redpanda-data/docs#1892 and redpanda-data/rp-connect-docs#485.

## ⚠️ Do not merge before redpanda-data/docs#1892

The `shared/` folder does not exist on docs `main` until #1892 lands. Merging this first points the playbook at a folder that isn't there, and the playbook loses the shared component entirely — no glossary terms, no enterprise features registry.

## Why this matters

This is a **local** playbook, so the published site is unaffected either way — the production cutover is docs-site#205. The cost of *not* doing this is that local previews in this repo silently lose the shared component once the `shared` branch is retired, which is easy to misread as a content bug.

Conversely, leaving any consumer on the branch means the `shared` branch can't be retired, and the folder and branch keep drifting. That drift already bit docs#1892: four glossary terms in the folder copy still carried the old `ADP` acronym after #1894 updated the branch.

## Verification

- YAML parses
- no `shared` entry remains in the docs source's `branches`
- exactly one source with `start_path: shared`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
