### PR TITLE
fix: bump Antora to 3.1.15 and drop the redirect-producer override

### DIFF
--- a/docs/local-antora-playbook.yml
+++ b/docs/local-antora-playbook.yml
@@ -89,7 +89,6 @@ antora:
     excludes: ['.thumbs','script', '.page-versions','.feedback-section','.banner-container']
   - require: '@redpanda-data/docs-extensions-and-macros/extensions/collect-bloblang-samples'
   - require: '@redpanda-data/docs-extensions-and-macros/extensions/generate-rp-connect-categories'
-  - require: '@redpanda-data/docs-extensions-and-macros/extensions/modify-redirects'
   - require: '@redpanda-data/docs-extensions-and-macros/extensions/unlisted-pages'
   - require: '@redpanda-data/docs-extensions-and-macros/extensions/find-related-docs'
   - require: '@redpanda-data/docs-extensions-and-macros/extensions/find-related-labs'

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@antora/cli": "3.1.2",
-        "@antora/site-generator": "3.1.2",
+        "@antora/cli": "3.1.15",
+        "@antora/site-generator": "3.1.15",
         "@asciidoctor/tabs": "^1.0.0-beta.5",
         "@redpanda-data/docs-extensions-and-macros": "^5.0.0",
         "@sntke/antora-mermaid-extension": "^0.0.6"
@@ -177,13 +177,13 @@
       }
     },
     "node_modules/@antora/asciidoc-loader": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@antora/asciidoc-loader/-/asciidoc-loader-3.1.2.tgz",
-      "integrity": "sha512-j5nNo8XastKxu8WYV9muCgRB4iGo88KIePIegcdQ5tcbuPmamOlp2/XuwYzGDAjWmaadqLD+3y9Mu18hA+wUYg==",
+      "version": "3.1.15",
+      "resolved": "https://registry.npmjs.org/@antora/asciidoc-loader/-/asciidoc-loader-3.1.15.tgz",
+      "integrity": "sha512-MVspbcMPmBgxZms0EjmyC9nlCAWBJfHYSwQCXRZn6T7OujRrLvJFPgz+EROz9XOqh4v76BeqgEuLsUJIZjH3cw==",
       "license": "MPL-2.0",
       "dependencies": {
-        "@antora/logger": "3.1.2",
-        "@antora/user-require-helper": "~2.0",
+        "@antora/logger": "3.1.15",
+        "@antora/user-require-helper": "~3.0",
         "@asciidoctor/core": "~2.2"
       },
       "engines": {
@@ -191,15 +191,15 @@
       }
     },
     "node_modules/@antora/cli": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@antora/cli/-/cli-3.1.2.tgz",
-      "integrity": "sha512-/0ddoM9ZsY41LPmow8ic6IG+PIiTik82YJTHCM8CHRme2oNHU1ZBaXbH6ClS9yBwwPzVzwt4Bc6A/yQ/5+2XCA==",
+      "version": "3.1.15",
+      "resolved": "https://registry.npmjs.org/@antora/cli/-/cli-3.1.15.tgz",
+      "integrity": "sha512-76vLhkyzyFd49WJHsC04oPAZlK4qWbJaeZdS/pLUUVBqgaxeSeNqpTZ0pXo7f+5laGRO19fXyk1eDWGus9h8jA==",
       "license": "MPL-2.0",
       "dependencies": {
-        "@antora/logger": "3.1.2",
-        "@antora/playbook-builder": "3.1.2",
-        "@antora/user-require-helper": "~2.0",
-        "commander": "~9.4"
+        "@antora/logger": "3.1.15",
+        "@antora/playbook-builder": "3.1.15",
+        "@antora/user-require-helper": "~3.0",
+        "commander": "~11.1"
       },
       "bin": {
         "antora": "bin/antora"
@@ -208,118 +208,210 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/@antora/cli/node_modules/commander": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/@antora/content-aggregator": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@antora/content-aggregator/-/content-aggregator-3.1.2.tgz",
-      "integrity": "sha512-gRseJBYO7DpyCa2vwkRM7e2ZQ8D7813Q91sn9fg94D+8H/Em4SborO057jkOOgsxNAcXsQgiHfX2X8L+S+Vkqg==",
+      "version": "3.1.15",
+      "resolved": "https://registry.npmjs.org/@antora/content-aggregator/-/content-aggregator-3.1.15.tgz",
+      "integrity": "sha512-w84rJRKx+C4dsSbOHmjg78oM2T6xP9JRDsxpXjTmlh9T4zlNELCB6AD5s6Gztt3S6wlTiCNFLZw0v/HEVtuhzQ==",
       "license": "MPL-2.0",
       "dependencies": {
-        "@antora/expand-path-helper": "~2.0",
-        "@antora/logger": "3.1.2",
-        "@antora/user-require-helper": "~2.0",
+        "@antora/expand-path-helper": "~3.0",
+        "@antora/logger": "3.1.15",
+        "@antora/user-require-helper": "~3.0",
         "braces": "~3.0",
         "cache-directory": "~2.0",
-        "glob-stream": "~7.0",
-        "hpagent": "~1.1",
-        "isomorphic-git": "~1.21",
+        "fast-glob": "~3.3",
+        "hpagent": "~1.2",
+        "isomorphic-git": "~1.25",
         "js-yaml": "~4.1",
         "multi-progress": "~4.0",
-        "picomatch": "~2.3",
+        "picomatch": "~4.0",
         "progress": "~2.0",
         "should-proxy": "~1.0",
         "simple-get": "~4.0",
-        "vinyl": "~2.2"
+        "vinyl": "~3.0"
       },
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@antora/content-aggregator/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/@antora/content-aggregator/node_modules/replace-ext": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-2.0.0.tgz",
+      "integrity": "sha512-UszKE5KVK6JvyD92nzMn9cDapSk6w/CaFZ96CnmDMUqH9oowfxF/ZjRITD25H4DnOQClLA4/j7jLGXXLVKxAug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@antora/content-aggregator/node_modules/vinyl": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-3.0.1.tgz",
+      "integrity": "sha512-0QwqXteBNXgnLCdWdvPQBX6FXRHtIH3VhJPTd5Lwn28tJXc34YqSCWUmkOvtJHBmB3gGoPtrOKk3Ts8/kEZ9aA==",
+      "license": "MIT",
+      "dependencies": {
+        "clone": "^2.1.2",
+        "remove-trailing-separator": "^1.1.0",
+        "replace-ext": "^2.0.0",
+        "teex": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/@antora/content-classifier": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@antora/content-classifier/-/content-classifier-3.1.2.tgz",
-      "integrity": "sha512-Kisp/VlnTFiG6YnEMyTCnFqXks1SG6AuYrUADCW+KmDuXI7xZGHrLJjFeTUIDp0+HzuW96TJUhuMB8UL9TDNFA==",
+      "version": "3.1.15",
+      "resolved": "https://registry.npmjs.org/@antora/content-classifier/-/content-classifier-3.1.15.tgz",
+      "integrity": "sha512-m7INbqJcXBZU04HdBMqfL/NvezC3aaJGHHa0KfzeEKICg5FT22cVsEp6mYTgJVT4HqRy7JPCn9UeZvoa9x+MzQ==",
       "license": "MPL-2.0",
       "dependencies": {
-        "@antora/asciidoc-loader": "3.1.2",
-        "@antora/logger": "3.1.2",
+        "@antora/asciidoc-loader": "3.1.15",
+        "@antora/logger": "3.1.15",
         "mime-types": "~2.1",
-        "vinyl": "~2.2"
+        "vinyl": "~3.0"
       },
       "engines": {
         "node": ">=16.0.0"
       }
     },
+    "node_modules/@antora/content-classifier/node_modules/replace-ext": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-2.0.0.tgz",
+      "integrity": "sha512-UszKE5KVK6JvyD92nzMn9cDapSk6w/CaFZ96CnmDMUqH9oowfxF/ZjRITD25H4DnOQClLA4/j7jLGXXLVKxAug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@antora/content-classifier/node_modules/vinyl": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-3.0.1.tgz",
+      "integrity": "sha512-0QwqXteBNXgnLCdWdvPQBX6FXRHtIH3VhJPTd5Lwn28tJXc34YqSCWUmkOvtJHBmB3gGoPtrOKk3Ts8/kEZ9aA==",
+      "license": "MIT",
+      "dependencies": {
+        "clone": "^2.1.2",
+        "remove-trailing-separator": "^1.1.0",
+        "replace-ext": "^2.0.0",
+        "teex": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/@antora/document-converter": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@antora/document-converter/-/document-converter-3.1.2.tgz",
-      "integrity": "sha512-zOFMK0wcmL3aZuO2k61MaWDZ86vzuG16YIIqebg/V0QZcSsS06Vvo79fplQz91KL2vPgB0+rl//Roqbr28MfUw==",
+      "version": "3.1.15",
+      "resolved": "https://registry.npmjs.org/@antora/document-converter/-/document-converter-3.1.15.tgz",
+      "integrity": "sha512-7YZsc/iIJVTxvHKy0/eqPTuRIJupBd7Pq49gWvCxiDBR9Zj4esqMZIU3HaIbkBgqJLlQv5TLBeTjiQ1Qpe1hNw==",
       "license": "MPL-2.0",
       "dependencies": {
-        "@antora/asciidoc-loader": "3.1.2"
+        "@antora/asciidoc-loader": "3.1.15"
       },
       "engines": {
         "node": ">=16.0.0"
       }
     },
     "node_modules/@antora/expand-path-helper": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@antora/expand-path-helper/-/expand-path-helper-2.0.0.tgz",
-      "integrity": "sha512-CSMBGC+tI21VS2kGW3PV7T2kQTM5eT3f2GTPVLttwaNYbNxDve08en/huzszHJfxo11CcEs26Ostr0F2c1QqeA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@antora/expand-path-helper/-/expand-path-helper-3.0.0.tgz",
+      "integrity": "sha512-7PdEIhk97v85/CSm3HynCsX14TR6oIVz1s233nNLsiWubE8tTnpPt4sNRJR+hpmIZ6Bx9c6QDp3XIoiyu/WYYA==",
       "license": "MPL-2.0",
       "engines": {
-        "node": ">=10.17.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@antora/file-publisher": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@antora/file-publisher/-/file-publisher-3.1.2.tgz",
-      "integrity": "sha512-yWE1E4kg5obAzX9nl/oYou86BlSeKCf9lONiYuWqeqdUdeZPxW5RE2YahJk6i9+9Zwrxgm65oc/oDdvsdwSqYw==",
+      "version": "3.1.15",
+      "resolved": "https://registry.npmjs.org/@antora/file-publisher/-/file-publisher-3.1.15.tgz",
+      "integrity": "sha512-UfLYeyD6Na9YXespr3Xjy6OPIAGG6GTbdW3SNn8KxHl3hGeF/AtM3NaR+AJgyOmTb2r9lHzfODXeZevqX+vMww==",
       "license": "MPL-2.0",
       "dependencies": {
-        "@antora/expand-path-helper": "~2.0",
-        "@antora/user-require-helper": "~2.0",
-        "gulp-vinyl-zip": "~2.5",
-        "vinyl": "~2.2",
-        "vinyl-fs": "~3.0"
+        "@antora/expand-path-helper": "~3.0",
+        "@antora/user-require-helper": "~3.0",
+        "vinyl": "~3.0",
+        "yazl": "~3.3"
       },
       "engines": {
         "node": ">=16.0.0"
       }
     },
+    "node_modules/@antora/file-publisher/node_modules/replace-ext": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-2.0.0.tgz",
+      "integrity": "sha512-UszKE5KVK6JvyD92nzMn9cDapSk6w/CaFZ96CnmDMUqH9oowfxF/ZjRITD25H4DnOQClLA4/j7jLGXXLVKxAug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@antora/file-publisher/node_modules/vinyl": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-3.0.1.tgz",
+      "integrity": "sha512-0QwqXteBNXgnLCdWdvPQBX6FXRHtIH3VhJPTd5Lwn28tJXc34YqSCWUmkOvtJHBmB3gGoPtrOKk3Ts8/kEZ9aA==",
+      "license": "MIT",
+      "dependencies": {
+        "clone": "^2.1.2",
+        "remove-trailing-separator": "^1.1.0",
+        "replace-ext": "^2.0.0",
+        "teex": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/@antora/logger": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@antora/logger/-/logger-3.1.2.tgz",
-      "integrity": "sha512-xmKCpchp0IU8SpKUa/AwlLsvOcO7edNjQ3dOzpxm223avCWm/lCnNBtC++lnLYE7jOfOFYjnhveE16JKPj6akA==",
+      "version": "3.1.15",
+      "resolved": "https://registry.npmjs.org/@antora/logger/-/logger-3.1.15.tgz",
+      "integrity": "sha512-txA2Nv0QQ+hIt6arc3Rrh1BiUJNlucsyNF7ZA7LgtN+rzxyjcqQPpbQ2F3tU2lOV/LOQCEvMbmz9Dj0tY8oBuA==",
       "license": "MPL-2.0",
       "dependencies": {
-        "@antora/expand-path-helper": "~2.0",
-        "pino": "~8.7",
-        "pino-pretty": "~9.1",
-        "sonic-boom": "~3.2"
+        "@antora/expand-path-helper": "~3.0",
+        "pino": "~9.2",
+        "pino-pretty": "~11.2",
+        "sonic-boom": "~4.0"
       },
       "engines": {
         "node": ">=16.0.0"
       }
     },
     "node_modules/@antora/navigation-builder": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@antora/navigation-builder/-/navigation-builder-3.1.2.tgz",
-      "integrity": "sha512-gWiFTZDfM31mHgHKs3og6e1/2y4idFFBLwTfXZWbgBlUDKmhWQKeg1CUQUzXR0Ts4SJhiViGlOzptPXQPQURtA==",
+      "version": "3.1.15",
+      "resolved": "https://registry.npmjs.org/@antora/navigation-builder/-/navigation-builder-3.1.15.tgz",
+      "integrity": "sha512-XRs4pfNd88GCG9lDAJ1J+2vwvre7OzNRSgRmZhEhtgv0A13NEZq37X4YuaH46F2kj2BqiZT8UOuxqAqarLaxmg==",
       "license": "MPL-2.0",
       "dependencies": {
-        "@antora/asciidoc-loader": "3.1.2"
+        "@antora/asciidoc-loader": "3.1.15"
       },
       "engines": {
         "node": ">=16.0.0"
       }
     },
     "node_modules/@antora/page-composer": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@antora/page-composer/-/page-composer-3.1.2.tgz",
-      "integrity": "sha512-rwYNEGh4cxQHsm+fEk4R+Wi2silRe5eCeyPvW52caXvfaTcmSK92iOnXMYpsthws5UmBV3D+1eSXbjMfe4xC7w==",
+      "version": "3.1.15",
+      "resolved": "https://registry.npmjs.org/@antora/page-composer/-/page-composer-3.1.15.tgz",
+      "integrity": "sha512-koKlhWilA0E0QdCCOeLLzCFLNViBVjNe3aIlmJnMCwAK0p85wyhVfyolNqbNejAvdCZ87YhUQJ52Q4ikCgkQQg==",
       "license": "MPL-2.0",
       "dependencies": {
-        "@antora/logger": "3.1.2",
+        "@antora/logger": "3.1.15",
         "handlebars": "~4.7",
         "require-from-string": "~2.0"
       },
@@ -328,9 +420,9 @@
       }
     },
     "node_modules/@antora/playbook-builder": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@antora/playbook-builder/-/playbook-builder-3.1.2.tgz",
-      "integrity": "sha512-hfQom+UDFXdfDZVscGLtSBHZzkoi2HL8mt2Iiu+xh/6FFiAwCpU8eAlFzYHz2+yf8OpaMytvVNavvJXe3uo3qw==",
+      "version": "3.1.15",
+      "resolved": "https://registry.npmjs.org/@antora/playbook-builder/-/playbook-builder-3.1.15.tgz",
+      "integrity": "sha512-L2bE9FS0Th/d37DeDjz/dg9YXrkHM1xI0WQB3eiW3K/6d0Mc7eJhbmDMT0K8S+hgdaO0AT4kqDWzvx2866ZobA==",
       "license": "MPL-2.0",
       "dependencies": {
         "@iarna/toml": "~2.2",
@@ -343,99 +435,195 @@
       }
     },
     "node_modules/@antora/redirect-producer": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@antora/redirect-producer/-/redirect-producer-3.1.2.tgz",
-      "integrity": "sha512-MUzjYH+2nKgW5oY9afkLzUdRsdSb+aOWF7BEPcvdCcA6/Gkm+fFs1bBATrtjjq70tbsKe6pMpsHEHqxuOz0WIQ==",
+      "version": "3.1.15",
+      "resolved": "https://registry.npmjs.org/@antora/redirect-producer/-/redirect-producer-3.1.15.tgz",
+      "integrity": "sha512-mV0KnRiTr9oi0hPm7okT/Bw8kkz+PWYxp9AVSGqzhkoQgr3crxhgyS0NFCoViHwjaj4NfQrf++yxbhr6Igd7Dw==",
       "license": "MPL-2.0",
       "dependencies": {
-        "vinyl": "~2.2"
+        "vinyl": "~3.0"
       },
       "engines": {
         "node": ">=16.0.0"
       }
     },
+    "node_modules/@antora/redirect-producer/node_modules/replace-ext": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-2.0.0.tgz",
+      "integrity": "sha512-UszKE5KVK6JvyD92nzMn9cDapSk6w/CaFZ96CnmDMUqH9oowfxF/ZjRITD25H4DnOQClLA4/j7jLGXXLVKxAug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@antora/redirect-producer/node_modules/vinyl": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-3.0.1.tgz",
+      "integrity": "sha512-0QwqXteBNXgnLCdWdvPQBX6FXRHtIH3VhJPTd5Lwn28tJXc34YqSCWUmkOvtJHBmB3gGoPtrOKk3Ts8/kEZ9aA==",
+      "license": "MIT",
+      "dependencies": {
+        "clone": "^2.1.2",
+        "remove-trailing-separator": "^1.1.0",
+        "replace-ext": "^2.0.0",
+        "teex": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/@antora/site-generator": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@antora/site-generator/-/site-generator-3.1.2.tgz",
-      "integrity": "sha512-BpdX3hcWhtPPpq4+lyQe1XLoaxSPd6dcB+AzQTpg5oIb3+mXte8Tie45WXmiCX9F1Dp6Ug9BDImf/2HJFsbG0Q==",
+      "version": "3.1.15",
+      "resolved": "https://registry.npmjs.org/@antora/site-generator/-/site-generator-3.1.15.tgz",
+      "integrity": "sha512-Z9YiRTqw3ssnLQxSHI3VZHEPLytQXt8cWC5C/o9vS+Fc560TSNs1UO4quPFIkg+bFUpxXtcAxqbp650aA4/N1g==",
       "license": "MPL-2.0",
       "dependencies": {
-        "@antora/asciidoc-loader": "3.1.2",
-        "@antora/content-aggregator": "3.1.2",
-        "@antora/content-classifier": "3.1.2",
-        "@antora/document-converter": "3.1.2",
-        "@antora/file-publisher": "3.1.2",
-        "@antora/logger": "3.1.2",
-        "@antora/navigation-builder": "3.1.2",
-        "@antora/page-composer": "3.1.2",
-        "@antora/playbook-builder": "3.1.2",
-        "@antora/redirect-producer": "3.1.2",
-        "@antora/site-mapper": "3.1.2",
-        "@antora/site-publisher": "3.1.2",
-        "@antora/ui-loader": "3.1.2",
-        "@antora/user-require-helper": "~2.0"
+        "@antora/asciidoc-loader": "3.1.15",
+        "@antora/content-aggregator": "3.1.15",
+        "@antora/content-classifier": "3.1.15",
+        "@antora/document-converter": "3.1.15",
+        "@antora/file-publisher": "3.1.15",
+        "@antora/logger": "3.1.15",
+        "@antora/navigation-builder": "3.1.15",
+        "@antora/page-composer": "3.1.15",
+        "@antora/playbook-builder": "3.1.15",
+        "@antora/redirect-producer": "3.1.15",
+        "@antora/site-mapper": "3.1.15",
+        "@antora/site-publisher": "3.1.15",
+        "@antora/ui-loader": "3.1.15",
+        "@antora/user-require-helper": "~3.0"
       },
       "engines": {
         "node": ">=16.0.0"
       }
     },
     "node_modules/@antora/site-mapper": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@antora/site-mapper/-/site-mapper-3.1.2.tgz",
-      "integrity": "sha512-WQEYac4KMIjc2H+5GUkzikgkZ1jSe8KXnDz9dzSL0A5zIwjVxlM2mnzAfzG8g1kKtlh1BwU4Famh97BfRzLQKg==",
+      "version": "3.1.15",
+      "resolved": "https://registry.npmjs.org/@antora/site-mapper/-/site-mapper-3.1.15.tgz",
+      "integrity": "sha512-dV5zGeL1uMQ83sfkBWKg8vjaJQXz1Zh3ZSNQZYa64HnT4M7oSuQUzwDZdS0j6ZtTiYcNGulRi1ucz3uIoc9tqw==",
       "license": "MPL-2.0",
       "dependencies": {
-        "@antora/content-classifier": "3.1.2",
-        "vinyl": "~2.2"
+        "@antora/content-classifier": "3.1.15",
+        "vinyl": "~3.0"
       },
       "engines": {
         "node": ">=16.0.0"
       }
     },
+    "node_modules/@antora/site-mapper/node_modules/replace-ext": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-2.0.0.tgz",
+      "integrity": "sha512-UszKE5KVK6JvyD92nzMn9cDapSk6w/CaFZ96CnmDMUqH9oowfxF/ZjRITD25H4DnOQClLA4/j7jLGXXLVKxAug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@antora/site-mapper/node_modules/vinyl": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-3.0.1.tgz",
+      "integrity": "sha512-0QwqXteBNXgnLCdWdvPQBX6FXRHtIH3VhJPTd5Lwn28tJXc34YqSCWUmkOvtJHBmB3gGoPtrOKk3Ts8/kEZ9aA==",
+      "license": "MIT",
+      "dependencies": {
+        "clone": "^2.1.2",
+        "remove-trailing-separator": "^1.1.0",
+        "replace-ext": "^2.0.0",
+        "teex": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/@antora/site-publisher": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@antora/site-publisher/-/site-publisher-3.1.2.tgz",
-      "integrity": "sha512-I/GeYypIVvpRH84amCWK3BUOEUplGpjx2rN+UgaXQ0UvBGVHrex6sfmS0G7R7g0cmK3X5hND44wTFxbaSBPUnw==",
+      "version": "3.1.15",
+      "resolved": "https://registry.npmjs.org/@antora/site-publisher/-/site-publisher-3.1.15.tgz",
+      "integrity": "sha512-pBuNxgA+H+WB5F4gA/gim5wKx/884QwlqOl0CpOY+6Fqn7h2ooHA7Tv6O47Tra1nZzNbIe3CQRoA5pnrX6zyRw==",
       "license": "MPL-2.0",
       "dependencies": {
-        "@antora/file-publisher": "3.1.2"
+        "@antora/file-publisher": "3.1.15"
       },
       "engines": {
         "node": ">=16.0.0"
       }
     },
     "node_modules/@antora/ui-loader": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@antora/ui-loader/-/ui-loader-3.1.2.tgz",
-      "integrity": "sha512-4tE7FT0pvvQ7PjGBe/NiRhqGdyfvx/8YSZJwcC2RLxFFusrv/8WlGjbgOVU+gGRFy1AKZDFgzbQWtJcyLjsyAQ==",
+      "version": "3.1.15",
+      "resolved": "https://registry.npmjs.org/@antora/ui-loader/-/ui-loader-3.1.15.tgz",
+      "integrity": "sha512-zYjF5ID7t6mUEJuMyeNW/AYu1U0026wZj58H0siGuaT5YhVoxZrfvZYWV5iCMntpKduMqkwZW/l+D4MIqjhFYQ==",
       "license": "MPL-2.0",
       "dependencies": {
-        "@antora/expand-path-helper": "~2.0",
+        "@antora/expand-path-helper": "~3.0",
         "braces": "~3.0",
         "cache-directory": "~2.0",
-        "glob-stream": "~7.0",
-        "gulp-vinyl-zip": "~2.5",
-        "hpagent": "~1.1",
+        "fast-glob": "~3.3",
+        "hpagent": "~1.2",
         "js-yaml": "~4.1",
-        "picomatch": "~2.3",
+        "picomatch": "~4.0",
         "should-proxy": "~1.0",
         "simple-get": "~4.0",
-        "vinyl": "~2.2"
+        "vinyl": "~3.0",
+        "yauzl": "~3.3"
       },
       "engines": {
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@antora/user-require-helper": {
+    "node_modules/@antora/ui-loader/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/@antora/ui-loader/node_modules/replace-ext": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@antora/user-require-helper/-/user-require-helper-2.0.0.tgz",
-      "integrity": "sha512-5fMfBZfw4zLoFdDAPMQX6Frik90uvfD8rXOA4UpXPOUikkX4uT1Rk6m0/4oi8oS3fcjiIl0k/7Nc+eTxW5TcQQ==",
-      "license": "MPL-2.0",
+      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-2.0.0.tgz",
+      "integrity": "sha512-UszKE5KVK6JvyD92nzMn9cDapSk6w/CaFZ96CnmDMUqH9oowfxF/ZjRITD25H4DnOQClLA4/j7jLGXXLVKxAug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@antora/ui-loader/node_modules/vinyl": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-3.0.1.tgz",
+      "integrity": "sha512-0QwqXteBNXgnLCdWdvPQBX6FXRHtIH3VhJPTd5Lwn28tJXc34YqSCWUmkOvtJHBmB3gGoPtrOKk3Ts8/kEZ9aA==",
+      "license": "MIT",
       "dependencies": {
-        "@antora/expand-path-helper": "~2.0"
+        "clone": "^2.1.2",
+        "remove-trailing-separator": "^1.1.0",
+        "replace-ext": "^2.0.0",
+        "teex": "^1.0.1"
       },
       "engines": {
-        "node": ">=10.17.0"
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/@antora/ui-loader/node_modules/yauzl": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.3.2.tgz",
+      "integrity": "sha512-Md9ankxxN23wncAN8s7+Tn3Co52zLUPMtnrLAbVCnfG5d2tKBFfmygYSgXlqFgXObtzIgqkx7aNgDBpso9+4qA==",
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@antora/user-require-helper": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@antora/user-require-helper/-/user-require-helper-3.0.0.tgz",
+      "integrity": "sha512-KIXb8WYhnrnwH7Jj21l1w+et9k5GvcgcqvLOwxqWLEd0uVZOiMFdqFjqbVm3M+zcrs1JXWMeh2LLvxBbQs3q/Q==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@antora/expand-path-helper": "~3.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@apidevtools/json-schema-ref-parser": {
@@ -1234,13 +1422,13 @@
       }
     },
     "node_modules/@asciidoctor/core": {
-      "version": "2.2.8",
-      "resolved": "https://registry.npmjs.org/@asciidoctor/core/-/core-2.2.8.tgz",
-      "integrity": "sha512-oozXk7ZO1RAd/KLFLkKOhqTcG4GO3CV44WwOFg2gMcCsqCUTarvMT7xERIoWW2WurKbB0/ce+98r01p8xPOlBw==",
+      "version": "2.2.9",
+      "resolved": "https://registry.npmjs.org/@asciidoctor/core/-/core-2.2.9.tgz",
+      "integrity": "sha512-tIPRHo1T2SFmAm+j77cDsj0RuaszP7xJxsaVTTAF5CwKyTbazw9TnIVlpIWM5yWfIWAWcAZy92RcnPgMJwny1w==",
       "license": "MIT",
       "dependencies": {
-        "asciidoctor-opal-runtime": "0.3.3",
-        "unxhr": "1.0.1"
+        "asciidoctor-opal-runtime": "0.3.4",
+        "unxhr": "~1.2"
       },
       "engines": {
         "node": ">=8.11",
@@ -2640,6 +2828,41 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/@octokit/auth-token": {
       "version": "5.1.2",
@@ -15347,13 +15570,13 @@
       "license": "MIT"
     },
     "node_modules/asciidoctor-opal-runtime": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/asciidoctor-opal-runtime/-/asciidoctor-opal-runtime-0.3.3.tgz",
-      "integrity": "sha512-/CEVNiOia8E5BMO9FLooo+Kv18K4+4JBFRJp8vUy/N5dMRAg+fRNV4HA+o6aoSC79jVU/aT5XvUpxSxSsTS8FQ==",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/asciidoctor-opal-runtime/-/asciidoctor-opal-runtime-0.3.4.tgz",
+      "integrity": "sha512-zqd6zn1LV+PZ69AP/kEbB00zuPHMIAJY3IX8+aZV+X1qOwatYvKGjsMmdMc5ApfhtkjZ4mYkqiTPJWnEnBiMJg==",
       "license": "MIT",
       "dependencies": {
-        "glob": "7.1.3",
-        "unxhr": "1.0.1"
+        "fast-glob": "~3.3",
+        "unxhr": "~1.2"
       },
       "engines": {
         "node": ">=8.11"
@@ -15475,6 +15698,21 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/axios": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
@@ -15491,7 +15729,6 @@
       "version": "1.6.7",
       "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.7.tgz",
       "integrity": "sha512-OnAYlL5b7LEkALw87fUVafQw5rVR9RjwGd4KUwNQ6DrrNmaVaUCgLipfVlzrPQ4tWOR9P0IXGNOx50jYCCdSJg==",
-      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/bach": {
@@ -15524,7 +15761,6 @@
       "version": "2.5.4",
       "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.5.4.tgz",
       "integrity": "sha512-+gFfDkR8pj4/TrWCGUGWmJIkBwuxPS5F+a5yWjOHQt2hHvNZd5YLzadjmDUtFmMM4y429bnKLa8bYBMHcYdnQA==",
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true
     },
@@ -15956,7 +16192,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
       "integrity": "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
@@ -16113,14 +16348,14 @@
       }
     },
     "node_modules/call-bind": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
-      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
       "license": "MIT",
       "dependencies": {
-        "call-bind-apply-helpers": "^1.0.0",
-        "es-define-property": "^1.0.0",
-        "get-intrinsic": "^1.2.4",
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
         "set-function-length": "^1.2.2"
       },
       "engines": {
@@ -16886,6 +17121,7 @@
       "version": "9.4.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.1.tgz",
       "integrity": "sha512-5EEkTNyHNGFPD2H+c/dXXfQZYa/scCKasxWcXJaWnNJ99pnQN9Vnmqow+p+PlFPE63Q6mThaZws1T+HxfpgtPw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^12.20.0 || >=14"
@@ -17105,9 +17341,9 @@
       "license": "MIT"
     },
     "node_modules/convict": {
-      "version": "6.2.4",
-      "resolved": "https://registry.npmjs.org/convict/-/convict-6.2.4.tgz",
-      "integrity": "sha512-qN60BAwdMVdofckX7AlohVJ2x9UvjTNoKVXCL2LxFk1l7757EJqf1nySdMkPQer0bt8kQ5lQiyZ9/2NvrFBuwQ==",
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/convict/-/convict-6.2.5.tgz",
+      "integrity": "sha512-JtXpxqDqJ8P0UwEHwhxLzCIXQy97vlYBZR222Sbzb1q1Erex9ASrztJ29SyhWFQjod1AeFBaPzEEC8YvtZMIYg==",
       "license": "Apache-2.0",
       "dependencies": {
         "lodash.clonedeep": "^4.5.0",
@@ -18941,8 +19177,23 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
       "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
     },
     "node_modules/fast-levenshtein": {
       "version": "1.1.4",
@@ -19026,6 +19277,15 @@
         "node": ">= 4.9.1"
       }
     },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
     "node_modules/faye-websocket": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
@@ -19042,6 +19302,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
       "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pend": "~1.2.0"
@@ -19416,6 +19677,21 @@
         "debug": {
           "optional": true
         }
+      }
+    },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/for-in": {
@@ -19799,29 +20075,10 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/glob": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
-      "deprecated": "Glob versions prior to v9 are no longer supported",
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/glob-parent": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -20641,44 +20898,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/gulp-vinyl-zip": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/gulp-vinyl-zip/-/gulp-vinyl-zip-2.5.0.tgz",
-      "integrity": "sha512-KPi5/2SUmkXXDvKU4L2U1dkPOP03SbhONTOgNZlL23l9Yopt+euJ1bBXwWrSMbsyh3JLW/TYuC8CI4c4Kq4qrw==",
-      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-      "license": "MIT",
-      "dependencies": {
-        "queue": "^4.2.1",
-        "through": "^2.3.8",
-        "through2": "^2.0.3",
-        "vinyl": "^2.0.2",
-        "vinyl-fs": "^3.0.3",
-        "yauzl": "^2.2.1",
-        "yazl": "^2.2.1"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/gulp-vinyl-zip/node_modules/buffer-crc32": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/gulp-vinyl-zip/node_modules/yauzl": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
-      "license": "MIT",
-      "dependencies": {
-        "buffer-crc32": "~0.2.3",
-        "fd-slicer": "~1.1.0"
-      }
-    },
     "node_modules/gulplog": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
@@ -20853,69 +21072,10 @@
       }
     },
     "node_modules/help-me": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/help-me/-/help-me-4.2.0.tgz",
-      "integrity": "sha512-TAOnTB8Tz5Dw8penUuzHVrKNKlCIbwwbHnXraNJxPwf8LRtE2HlM84RYuezMFcwOJmoYOCWVDyJ8TQGxn9PgxA==",
-      "license": "MIT",
-      "dependencies": {
-        "glob": "^8.0.0",
-        "readable-stream": "^3.6.0"
-      }
-    },
-    "node_modules/help-me/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/help-me/node_modules/glob": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
-      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
-      "deprecated": "Glob versions prior to v9 are no longer supported",
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^5.0.1",
-        "once": "^1.3.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/help-me/node_modules/minimatch": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/help-me/node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/help-me/-/help-me-5.0.0.tgz",
+      "integrity": "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==",
+      "license": "MIT"
     },
     "node_modules/homedir-polyfill": {
       "version": "1.0.3",
@@ -20995,9 +21155,9 @@
       }
     },
     "node_modules/hpagent": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/hpagent/-/hpagent-1.1.0.tgz",
-      "integrity": "sha512-bgJcBmNTZaJO03xtXOTNfoFEf/3VwoZ/gJ2O4ekTCZu4LSFtfzQFrJ0kjq8ZSS0+IdghXqQIiDUnpp0eUR9IJg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/hpagent/-/hpagent-1.2.0.tgz",
+      "integrity": "sha512-A91dYTeIB6NoXG+PxTQpCCDDnfHsW9kc06Lvpu1TEe9gnd6ZFeiBoRO9JvzEv6xK7EX97/dUE8g/vBMTqTS3CA==",
       "license": "MIT",
       "engines": {
         "node": ">=14"
@@ -21467,6 +21627,18 @@
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
       "license": "MIT"
     },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-core-module": {
       "version": "2.16.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
@@ -21758,6 +21930,21 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-unc-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-1.0.0.tgz",
@@ -21884,12 +22071,12 @@
       }
     },
     "node_modules/isomorphic-git": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/isomorphic-git/-/isomorphic-git-1.21.0.tgz",
-      "integrity": "sha512-ZqCAUM63CYepA3fB8H7NVyPSiOkgzIbQ7T+QPrm9xtYgQypN9JUJ5uLMjB5iTfomdJf3mdm6aSxjZwnT6ubvEA==",
+      "version": "1.25.10",
+      "resolved": "https://registry.npmjs.org/isomorphic-git/-/isomorphic-git-1.25.10.tgz",
+      "integrity": "sha512-IxGiaKBwAdcgBXwIcxJU6rHLk+NrzYaaPKXXQffcA0GW3IUrQXdUPDXDo+hkGVcYruuz/7JlGBiuaeTCgIgivQ==",
       "license": "MIT",
       "dependencies": {
-        "async-lock": "^1.1.0",
+        "async-lock": "^1.4.1",
         "clean-git-ref": "^2.0.1",
         "crc-32": "^1.2.0",
         "diff3": "0.0.3",
@@ -23192,6 +23379,15 @@
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/method-override": {
       "version": "3.0.0",
@@ -24877,31 +25073,31 @@
       }
     },
     "node_modules/pino": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-8.7.0.tgz",
-      "integrity": "sha512-l9sA5uPxmZzwydhMWUcm1gI0YxNnYl8MfSr2h8cwLvOAzQLBLewzF247h/vqHe3/tt6fgtXeG9wdjjoetdI/vA==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-9.2.0.tgz",
+      "integrity": "sha512-g3/hpwfujK5a4oVbaefoJxezLzsDgLcNJeITvC6yrfwYeT9la+edCK42j5QpEQSQCZgTKapXvnQIdgZwvRaZug==",
       "license": "MIT",
       "dependencies": {
         "atomic-sleep": "^1.0.0",
         "fast-redact": "^3.1.1",
         "on-exit-leak-free": "^2.1.0",
-        "pino-abstract-transport": "v1.0.0",
-        "pino-std-serializers": "^6.0.0",
-        "process-warning": "^2.0.0",
+        "pino-abstract-transport": "^1.2.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^3.0.0",
         "quick-format-unescaped": "^4.0.3",
         "real-require": "^0.2.0",
         "safe-stable-stringify": "^2.3.1",
-        "sonic-boom": "^3.1.0",
-        "thread-stream": "^2.0.0"
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^3.0.0"
       },
       "bin": {
         "pino": "bin.js"
       }
     },
     "node_modules/pino-abstract-transport": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.0.0.tgz",
-      "integrity": "sha512-c7vo5OpW4wIS42hUVcT5REsL8ZljsUfBjqV/e2sFxmFEFZiq1XLUp5EYLtuDH6PEHq9W1egWqRbnLUP5FuZmOA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.2.0.tgz",
+      "integrity": "sha512-Guhh8EZfPCfH+PMXAb6rKOjGQEoy0xlAIn+irODG5kgfYV+BQ0rGYYWTIel3P5mmyXqkYkPmdIkywsn6QKUR1Q==",
       "license": "MIT",
       "dependencies": {
         "readable-stream": "^4.0.0",
@@ -24909,16 +25105,16 @@
       }
     },
     "node_modules/pino-pretty": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-9.1.1.tgz",
-      "integrity": "sha512-iJrnjgR4FWQIXZkUF48oNgoRI9BpyMhaEmihonHeCnZ6F50ZHAS4YGfGBT/ZVNsPmd+hzkIPGzjKdY08+/yAXw==",
+      "version": "11.2.2",
+      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-11.2.2.tgz",
+      "integrity": "sha512-2FnyGir8nAJAqD3srROdrF1J5BIcMT4nwj7hHSc60El6Uxlym00UbCCd8pYIterstVBFlMyF1yFV8XdGIPbj4A==",
       "license": "MIT",
       "dependencies": {
         "colorette": "^2.0.7",
         "dateformat": "^4.6.3",
-        "fast-copy": "^3.0.0",
+        "fast-copy": "^3.0.2",
         "fast-safe-stringify": "^2.1.1",
-        "help-me": "^4.0.1",
+        "help-me": "^5.0.0",
         "joycon": "^3.1.1",
         "minimist": "^1.2.6",
         "on-exit-leak-free": "^2.1.0",
@@ -24926,7 +25122,7 @@
         "pump": "^3.0.0",
         "readable-stream": "^4.0.0",
         "secure-json-parse": "^2.4.0",
-        "sonic-boom": "^3.0.0",
+        "sonic-boom": "^4.0.1",
         "strip-json-comments": "^3.1.1"
       },
       "bin": {
@@ -24934,9 +25130,9 @@
       }
     },
     "node_modules/pino-std-serializers": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-6.2.2.tgz",
-      "integrity": "sha512-cHjPPsE+vhj/tnhCy/wiMh3M3z3h/j15zHQX+S9GkTBgqJuTuJzYJ4gUyACLhDaJ7kk9ba9iRDmbH2tJU03OiA==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
+      "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
       "license": "MIT"
     },
     "node_modules/pixelmatch": {
@@ -25053,6 +25249,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/postcss-value-parser": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
@@ -25106,9 +25311,9 @@
       "license": "MIT"
     },
     "node_modules/process-warning": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-2.3.2.tgz",
-      "integrity": "sha512-n9wh8tvBe5sFmsqlg+XQhaQLumwpqoAUruLwjCopgTmUBjJ/fjtBsJzKleCaIGBOMXYEhp1YfKl4d7rJ5ZKJGA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-3.0.0.tgz",
+      "integrity": "sha512-mqn0kFRl0EoqhnL0GQ0veqFHyIN1yig9RHh/InzORTUiZHFRAur+aMtRkELNwGs9aNwKS6tg/An4NYBPGwvtzQ==",
       "license": "MIT"
     },
     "node_modules/progress": {
@@ -25434,15 +25639,6 @@
       "integrity": "sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/queue": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/queue/-/queue-4.5.1.tgz",
-      "integrity": "sha512-AMD7w5hRXcFSb8s9u38acBZ+309u6GsiibP4/0YacJeaurRshogB7v/ZcVPxP5gD5+zIw6ixRHdutiYUJfwKHw==",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "~2.0.0"
-      }
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -26185,6 +26381,16 @@
         "node": ">=0.12"
       }
     },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/rgb2hex": {
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/rgb2hex/-/rgb2hex-0.2.5.tgz",
@@ -26344,6 +26550,29 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
       }
     },
     "node_modules/safaridriver": {
@@ -26775,16 +27004,23 @@
       "license": "ISC"
     },
     "node_modules/sha.js": {
-      "version": "2.4.11",
-      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
-      "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+      "version": "2.4.12",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.12.tgz",
+      "integrity": "sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==",
       "license": "(MIT AND BSD-3-Clause)",
       "dependencies": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
+        "inherits": "^2.0.4",
+        "safe-buffer": "^5.2.1",
+        "to-buffer": "^1.2.0"
       },
       "bin": {
         "sha.js": "bin.js"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/sharp": {
@@ -27327,9 +27563,9 @@
       }
     },
     "node_modules/sonic-boom": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-3.2.1.tgz",
-      "integrity": "sha512-iITeTHxy3B9FGu8aVdiDXUVAcHMF9Ss0cCsAOo2HfCrmVGT3/DT5oYaeu0M/YKZDlKTvChEyPq0zI9Hf33EX6A==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.0.1.tgz",
+      "integrity": "sha512-hTSD/6JMLyT4r9zeof6UtuBDpjJ9sO08/nmS5djaA9eozT9oOlNdpXSnzcgj4FTqpk3nkLrs61l4gip9r1HCrQ==",
       "license": "MIT",
       "dependencies": {
         "atomic-sleep": "^1.0.0"
@@ -27610,7 +27846,6 @@
       "version": "2.22.0",
       "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.22.0.tgz",
       "integrity": "sha512-sLh1evHOzBy/iWRiR6d1zRcLao4gGZr3C1kzNz4fopCOKJb6xD9ub8Mpi9Mr1R6id5o43S+d93fI48UC5uM9aw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-fifo": "^1.3.2",
@@ -28072,6 +28307,15 @@
         "npm": ">=8"
       }
     },
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "license": "MIT",
+      "dependencies": {
+        "streamx": "^2.12.5"
+      }
+    },
     "node_modules/temp-dir": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-3.0.0.tgz",
@@ -28131,7 +28375,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.3.tgz",
       "integrity": "sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "b4a": "^1.6.4"
@@ -28189,9 +28432,9 @@
       }
     },
     "node_modules/thread-stream": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-2.7.0.tgz",
-      "integrity": "sha512-qQiRWsU/wvNolI6tbbCKd9iKaTnCXsTwVxhhKM6nctPdujTyztjlbUkUTUymidWcMnZ5pWR0ej4a0tjsW021vw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.2.0.tgz",
+      "integrity": "sha512-zLBvqpwr4Esa0kRjcrzGU6zL25lePWaCLMx0RQFrmteozIfeNdaMLpG5U7PeHzvlFkAWaRKA9/KVW4F60iB+qw==",
       "license": "MIT",
       "dependencies": {
         "real-require": "^0.2.0"
@@ -28201,6 +28444,7 @@
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/through2": {
@@ -28310,6 +28554,26 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/to-buffer": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.2.tgz",
+      "integrity": "sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==",
+      "license": "MIT",
+      "dependencies": {
+        "isarray": "^2.0.5",
+        "safe-buffer": "^5.2.1",
+        "typed-array-buffer": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/to-buffer/node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "license": "MIT"
     },
     "node_modules/to-object-path": {
       "version": "0.3.0",
@@ -28556,6 +28820,20 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/typed-array-buffer": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/typedarray": {
@@ -28809,9 +29087,9 @@
       }
     },
     "node_modules/unxhr": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/unxhr/-/unxhr-1.0.1.tgz",
-      "integrity": "sha512-MAhukhVHyaLGDjyDYhy8gVjWJyhTECCdNsLwlMoGFoNJ3o79fpQhtQuzmAE4IxCMDwraF4cW8ZjpAV0m9CRQbg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/unxhr/-/unxhr-1.2.0.tgz",
+      "integrity": "sha512-6cGpm8NFXPD9QbSNx0cD2giy7teZ6xOkCUH3U89WKVkL9N9rBrWjlCwhR94Re18ZlAop4MOc3WU1M3Hv/bgpIw==",
       "license": "MIT",
       "engines": {
         "node": ">=8.11"
@@ -29504,6 +29782,27 @@
       "integrity": "sha512-F6+WgncZi/mJDrammbTuHe1q0R5hOXv/mBaiNA2TCNT/LTHusX0V+CJnj9XT8ki5ln2UZyyddDgHfCzyrOH7MQ==",
       "license": "ISC"
     },
+    "node_modules/which-typed-array": {
+      "version": "1.1.22",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
+      "integrity": "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==",
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/winston": {
       "version": "3.17.0",
       "resolved": "https://registry.npmjs.org/winston/-/winston-3.17.0.tgz",
@@ -29858,21 +30157,12 @@
       }
     },
     "node_modules/yazl": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/yazl/-/yazl-2.5.1.tgz",
-      "integrity": "sha512-phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/yazl/-/yazl-3.3.1.tgz",
+      "integrity": "sha512-BbETDVWG+VcMUle37k5Fqp//7SDOK2/1+T7X8TD96M3D9G8jK5VLUdQVdVjGi8im7FGkazX7kk5hkU8X4L5Bng==",
       "license": "MIT",
       "dependencies": {
-        "buffer-crc32": "~0.2.3"
-      }
-    },
-    "node_modules/yazl/node_modules/buffer-crc32": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
+        "buffer-crc32": "^1.0.0"
       }
     },
     "node_modules/ylru": {

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "test-migrator": "cd setup-tests && npx doc-detective runTests --input ../docker-compose/redpanda-migrator-demo/README.adoc -l debug"
   },
   "dependencies": {
-    "@antora/cli": "3.1.2",
-    "@antora/site-generator": "3.1.2",
+    "@antora/cli": "3.1.15",
+    "@antora/site-generator": "3.1.15",
     "@asciidoctor/tabs": "^1.0.0-beta.5",
     "@redpanda-data/docs-extensions-and-macros": "^5.0.0",
     "@sntke/antora-mermaid-extension": "^0.0.6"


### PR DESCRIPTION
## Summary
- Bumps `@antora/cli` / `@antora/site-generator` from `3.1.2` → `3.1.15` (matching the pin already used in `docs`).
- Removes the `@redpanda-data/docs-extensions-and-macros/extensions/modify-redirects` require from `docs/local-antora-playbook.yml`.

## Why
`@antora/redirect-producer` 3.1.2 predates the upstream fix for self-referential aliases (`delete it.out` before dispatching to the redirect facility), which landed in 3.1.8. `modify-redirects` was a fork of that module written to work around the bug. It's now being deleted upstream in redpanda-data/docs-extensions-and-macros#273, since Antora's real `redirect-producer` is called automatically by `@antora/site-generator` and no override is needed once the fix is present.

Removing the override here without first bumping Antora would trade one bug (the override's own drift/defects) for a worse one: a real self-referential redirect loop, since 3.1.2 doesn't have the fix. This PR bumps Antora first, then removes the override, so neither bug is present at any point in this diff.

## Verification
- `npm install` resolves both `@antora/cli` and `@antora/site-generator` to `3.1.15`.
- Confirmed the installed `node_modules/@antora/redirect-producer/lib/produce-redirects.js` contains the `delete it.out` fix.
- Ran a real build (`docs/local-antora-playbook.yml`, `--fetch`): `exit=1` both on this branch and on a fresh, unmodified control clone of `main`. The nonzero exit is pre-existing and unrelated to this change — it comes from a benign unresolved-xref asciidoctor warning (`reference:environment-variables.adoc`, sourced from cross-repo content), not from anything redirect- or module-related. No `Cannot find module` or redirect-producer errors appear in either build's log.

## Test plan
- [ ] CI build passes (or fails identically to `main`, per the pre-existing `exit=1` noted above)
- [ ] Confirm no self-referential or double-slash entries appear in the generated `_redirects` once this and redpanda-data/docs-extensions-and-macros#273 are both live

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>